### PR TITLE
Feat/metadata w04

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -680,7 +680,8 @@
     "metadata": {
       "logoURI": "https://cdn.morpho.org/assets/logos/usde.svg",
       "alternativeHardcodedOracles": [
-        "DAI"
+        "DAI",
+        "USDC"
       ],
       "tags": [
         "stablecoin",

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -6009,6 +6009,9 @@
     "symbol": "SEAM",
     "decimals": 18,
     "name": "Seamlesss",
+    "metadata": {
+      "logoURI": "https://cdn.morpho.org/assets/logos/seam.svg"
+    },
     "isWhitelisted": true
   },
   {


### PR DESCRIPTION
- hardcodes USDe to USDC to change market warning
FIXES INTEG-1407


- adds logoUrl metadata for Seamless token