### PR TITLE
feat(uXRP): whitelisting the universal XRP token

### DIFF
--- a/data/oracle-prices.json
+++ b/data/oracle-prices.json
@@ -306,6 +306,15 @@
     "contractChainId": 1
   },
   {
+    "assetAddress": "0x2615a94df961278DcbC41Fb0a54fEc5f10a693aE",
+    "contractAddress": "0xC0F566304A44d27c40d4F81D629520Ac4eD1850E",
+    "order": 0,
+    "type": "pyth_network",
+    "data": "{\"decimals\": 8, \"first_block_number\": 25942916}",
+    "assetChainId": 8453,
+    "contractChainId": 8453
+  },
+  {
     "assetAddress": "0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42",
     "contractAddress": "0xc95cd3490be4af06F0A25435e21C2c91B988C482",
     "order": 0,

--- a/data/price-feeds.json
+++ b/data/price-feeds.json
@@ -4214,6 +4214,21 @@
   },
   {
     "chainId": 8453,
+    "address": "0xC0F566304A44d27c40d4F81D629520Ac4eD1850E",
+    "vendor": "Pyth Network",
+    "description": "uXRP / USD Pyth price feed",
+    "pair": ["uXRP", "USD"],
+    "tokenIn": {
+      "address": "0x2615a94df961278DcbC41Fb0a54fEc5f10a693aE",
+      "chainId": 8453
+    },
+    "tokenOut": {
+      "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+      "chainId": 8453
+    }
+  },
+  {
+    "chainId": 8453,
     "address": "0x1b4671313DfA19B2F9B20eC2410712BC7CE6A89F",
     "vendor": "Pyth Network",
     "description": "SUI / USD Pyth price feed",

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -78,6 +78,17 @@
     "isWhitelisted": true
   },
   {
+    "chainId": 8453,
+    "address": "0x2615a94df961278DcbC41Fb0a54fEc5f10a693aE",
+    "name": "XRP (Universal)",
+    "symbol": "uXRP",
+    "decimals": 18,
+    "metadata": {
+      "logoURI": "https://cdn.morpho.org/assets/logos/uxrp.svg"
+    },
+    "isWhitelisted": true
+  },
+  {
     "name": "Wrapped Ether",
     "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
     "symbol": "WETH",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e01a3818-3b4a-465c-96f7-77350e90d63b)

uXRP 1:1 with XRP. And as XRP does not exist on the blockchain, I had to bypass the alternativeOracle attribute we are used to doing as XRP doesn't exist.

https://www.pyth.network/price-feeds/crypto-xrp-usd
