### PR TITLE
feat(tags):add btc to tbtc

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -3578,7 +3578,8 @@
     "decimals": 18,
     "name": "tBTC",
     "metadata": {
-      "logoURI": "https://cdn.morpho.org/assets/logos/tbtc.svg"
+      "logoURI": "https://cdn.morpho.org/assets/logos/tbtc.svg",
+      "tags": ["btc"]
     },
     "isWhitelisted": true
   },


### PR DESCRIPTION
**Problem**: tBTC vault not included in the V2 btc filter

**Solution**: Add btc tag to the tBTC asset

FIXES INTEG-1557