### PR TITLE
feat(whitelist): add curators whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It includes:
 5. [Tokens whitelisting](#5-tokens-whitelisting)
 6. [Exchange rate](#6-exchange-rate)
 7. [Custom warnings](#7-custom-warnings)
+8. [Curator whitelisting](#8-curator-whitelisting)
 
 > The format of the data folder SHOULD NOT be modified, in order to let the api read the data.
 
@@ -374,3 +375,56 @@ Each exchange rate entry must include:
 In case of emergency, or particular situation, Morpho Labs team is able to add custom warnings to some vaults or markets displayed on the Morpho Interface.
 
 [custom-warnings.json](./data/custom-warnings.json)
+
+## 8. Curator whitelisting
+
+Controls the known curators and the addresses they manage.
+
+> [!Note]
+> Any vault that have an `owner` or a `curator` address referenced as managed by a curator will automatically be flagged as curated by this curator
+
+### Required Fields
+
+Each curator entry must include the following fields:
+
+- `name`: Name of the curator organization
+- `image`: URL to the curator's logo/image (optional)
+- `url`: Website URL of the curator (optional)
+- `verified`: Boolean indicating curator verification status
+- `addresses`: List of addresses managed by this curator, on each chain (optional)
+
+> [!Note]
+> An address can be managed by different curators
+
+### Validation Rules
+
+1. Addresses must be in checksum format
+2. All required fields must be present and of the correct type
+
+### Example Entry
+
+```json
+  {
+    "image": "https://cdn.morpho.org/v2/assets/images/gauntlet.svg",
+    "name": "Gauntlet",
+    "url": "https://www.gauntlet.xyz/",
+    "verified": true,
+    "addresses": {
+      "1": [
+        "0x9E33faAE38ff641094fa68c65c2cE600b3410585",
+        "0xC684c6587712e5E7BDf9fD64415F23Bd2b05fAec",
+        "0xAC15982Ca8A8e8BAc738FE492b84D8761B4384a3",
+        "0x259c444b50e3Ab173c4f850BB40d85A9EA0230F3"
+      ],
+      "8453": [
+        "0x9E33faAE38ff641094fa68c65c2cE600b3410585",
+        "0x5a4E19842e09000a582c20A4f524C26Fb48Dd4D0",
+        "0x639d2dD24304aC2e6A691d8c1cFf4a2665925fee"
+      ]
+    }
+  },
+```
+
+### Files
+
+[curators-whitelist.json](./data/curators-whitelist.json)

--- a/README.md
+++ b/README.md
@@ -381,7 +381,9 @@ In case of emergency, or particular situation, Morpho Labs team is able to add c
 Controls the known curators and the addresses they manage.
 
 > [!Note]
-> Any vault that have an `owner` or a `curator` address referenced as managed by a curator will automatically be flagged as curated by this curator
+> Any vault that have an `owner` or a `curator` address referenced as managed by a curator will automatically be flagged as curated by this curator, unless the `owner` is unknown [*].
+
+_[*] This is to prevent anyone from having their vault flagged as "curated by X" just by setting any whitelisted address as `curator`_
 
 ### Required Fields
 

--- a/data/curators-whitelist.json
+++ b/data/curators-whitelist.json
@@ -1,0 +1,160 @@
+[
+  {
+    "image": "https://cdn.morpho.org/v2/assets/images/mevcapital.png",
+    "name": "MEV Capital",
+    "url": "https://mevcapital.com/",
+    "verified": true,
+    "addresses": {
+      "1": [
+        "0x38afC3aA2c76b4cA1F8e1DabA68e998e1F4782DB",
+        "0x06590Fef209Ebc1f8eEF83dA05984cD4eFf0d0E3"
+      ]
+    }
+  },
+  {
+    "image": "https://cdn.morpho.org/v2/assets/images/gauntlet.svg",
+    "name": "Gauntlet",
+    "url": "https://www.gauntlet.xyz/",
+    "verified": true,
+    "addresses": {
+      "1": [
+        "0x9E33faAE38ff641094fa68c65c2cE600b3410585",
+        "0xC684c6587712e5E7BDf9fD64415F23Bd2b05fAec",
+        "0xAC15982Ca8A8e8BAc738FE492b84D8761B4384a3",
+        "0x259c444b50e3Ab173c4f850BB40d85A9EA0230F3"
+      ],
+      "8453": [
+        "0x9E33faAE38ff641094fa68c65c2cE600b3410585",
+        "0x5a4E19842e09000a582c20A4f524C26Fb48Dd4D0",
+        "0x639d2dD24304aC2e6A691d8c1cFf4a2665925fee"
+      ]
+    }
+  },
+  {
+    "image": "https://cdn.morpho.org/v2/assets/images/9summits.png",
+    "name": "9Summits",
+    "url": "https://9summits.io/",
+    "verified": true,
+    "addresses": {
+      "1": [
+        "0x59e608E4842162480591032f3c8b0aE55C98d104",
+        "0x23E6aecB76675462Ad8f2B31eC7C492060c2fAEF"
+      ],
+      "8453": [
+        "0x59e608E4842162480591032f3c8b0aE55C98d104",
+        "0x23E6aecB76675462Ad8f2B31eC7C492060c2fAEF"
+      ]
+    }
+  },
+  {
+    "image": "https://cdn.morpho.org/v2/assets/images/block-analitica.png",
+    "name": "Block Analitica",
+    "url": "https://morpho.blockanalitica.com/",
+    "verified": true,
+    "addresses": {
+      "1": [
+        "0x2a933dbd0D9e32593e62702028Edcab437CE3cBA",
+        "0x2566f66f68ed438726AD904524FB306A03FdB80B"
+      ],
+      "8453": [
+        "0x4b8f6CADb8A2B222e8840E8aDDc32E031794A4D6",
+        "0x8b621804a7637b781e2BbD58e256a591F2dF7d51"
+      ]
+    }
+  },
+  {
+    "image": "https://cdn.morpho.org/v2/assets/images/bprotocol.png",
+    "name": "B.Protocol",
+    "url": "https://www.bprotocol.org/",
+    "verified": true,
+    "addresses": {
+      "1": [
+        "0xD6D14E60c0DAFcB3B77B296fe718623Ec84e5eb3",
+        "0x2a933dbd0D9e32593e62702028Edcab437CE3cBA",
+        "0x2566f66f68ed438726AD904524FB306A03FdB80B"
+      ],
+      "8453": [
+        "0x4b8f6CADb8A2B222e8840E8aDDc32E031794A4D6",
+        "0x8b621804a7637b781e2BbD58e256a591F2dF7d51",
+        "0x32f75c3ee6aD872Eb3138020885E94E2842b8433"
+      ]
+    }
+  },
+  {
+    "image": "https://cdn.morpho.org/v2/assets/images/re7.png",
+    "name": "RE7 Labs",
+    "url": "https://www.re7.capital",
+    "verified": true,
+    "addresses": {
+      "1": ["0xE86399fE6d7007FdEcb08A2ee1434Ee677a04433"],
+      "8453": ["0xD8B0F4e54a8dac04E0A57392f5A630cEdb99C940"]
+    }
+  },
+  {
+    "image": "https://cdn.morpho.org/v2/assets/images/fence.svg",
+    "name": "Fence",
+    "url": "https://www.fence.finance/",
+    "verified": true,
+    "addresses": { "1": ["0xF92971B4D9e6257CF562400ed81d2986F28a8c26"] }
+  },
+  {
+    "image": "https://cdn.morpho.org/v2/assets/images/steakhouse.svg",
+    "name": "Steakhouse Financial",
+    "url": "https://www.steakhouse.financial/projects/risk-management-framework-for-defi-protocols",
+    "verified": true,
+    "addresses": {
+      "1": [
+        "0x0A0e559bc3b0950a7e448F0d4894db195b9cf8DD",
+        "0x255c7705e8BB334DfCae438197f7C4297988085a",
+        "0xc01Ba42d4Bd241892B813FA8bD4589EAA4C60672"
+      ],
+      "8453": ["0x0A0e559bc3b0950a7e448F0d4894db195b9cf8DD"]
+    }
+  },
+  {
+    "image": "https://cdn.morpho.org/v2/assets/images/relend.png",
+    "name": "Relend Network",
+    "url": "https://relend.network/",
+    "verified": true,
+    "addresses": {
+      "1": ["0xD6D14E60c0DAFcB3B77B296fe718623Ec84e5eb3"],
+      "8453": ["0x32f75c3ee6aD872Eb3138020885E94E2842b8433"]
+    }
+  },
+  {
+    "image": "https://cdn.morpho.org/v2/assets/images/spark.svg",
+    "name": "SparkDAO",
+    "url": "https://spark.fi/",
+    "verified": true,
+    "addresses": {
+      "1": ["0x3300f198988e4C9C63F75dF86De36421f06af8c4"],
+      "8453": ["0xF93B7122450A50AF3e5A76E1d546e95Ac1d0F579"]
+    }
+  },
+  {
+    "image": "https://cdn.morpho.org/assets/logos/crvusd.svg",
+    "name": "LlamaRisk",
+    "url": "https://www.llamarisk.com/",
+    "verified": true,
+    "addresses": { "1": ["0x7e246fAce452AC43F5dC60c41EE14C88c37951c6"] }
+  },
+  {
+    "image": "https://cdn.morpho.org/v2/assets/images/apostro.svg",
+    "name": "Apostro",
+    "url": "https://apostro.xyz",
+    "verified": true,
+    "addresses": { "1": ["0xf726311F85D45a7fECfFbC94bD8508a0A39958c6"] }
+  },
+  {
+    "image": "https://cdn.morpho.org/v2/assets/images/leadblock.png",
+    "name": "LeadBlock",
+    "url": "https://leadblockpartners.com/",
+    "verified": true,
+    "addresses": {
+      "1": [
+        "0x825214AFa86f1F192F2FbA98FCB530EAdb473a5D",
+        "0x54f90Cbed0ba50fE7eE6113d8651eBdbF35938e2"
+      ]
+    }
+  }
+]

--- a/data/curators-whitelist.json
+++ b/data/curators-whitelist.json
@@ -19,14 +19,11 @@
     "addresses": {
       "1": [
         "0x9E33faAE38ff641094fa68c65c2cE600b3410585",
-        "0xC684c6587712e5E7BDf9fD64415F23Bd2b05fAec",
-        "0xAC15982Ca8A8e8BAc738FE492b84D8761B4384a3",
-        "0x259c444b50e3Ab173c4f850BB40d85A9EA0230F3"
+        "0xC684c6587712e5E7BDf9fD64415F23Bd2b05fAec"
       ],
       "8453": [
         "0x9E33faAE38ff641094fa68c65c2cE600b3410585",
-        "0x5a4E19842e09000a582c20A4f524C26Fb48Dd4D0",
-        "0x639d2dD24304aC2e6A691d8c1cFf4a2665925fee"
+        "0x5a4E19842e09000a582c20A4f524C26Fb48Dd4D0"
       ]
     }
   },
@@ -49,22 +46,18 @@
   {
     "image": "https://cdn.morpho.org/v2/assets/images/block-analitica.png",
     "name": "Block Analitica",
-    "url": "https://morpho.blockanalitica.com/",
+    "url": "https://blockanalitica.com/",
     "verified": true,
     "addresses": {
       "1": [
         "0x2a933dbd0D9e32593e62702028Edcab437CE3cBA",
         "0x2566f66f68ed438726AD904524FB306A03FdB80B"
       ],
-      "8453": [
-        "0x4b8f6CADb8A2B222e8840E8aDDc32E031794A4D6",
-        "0x8b621804a7637b781e2BbD58e256a591F2dF7d51"
-      ]
+      "8453": ["0x4b8f6CADb8A2B222e8840E8aDDc32E031794A4D6"]
     }
   },
   {
     "image": "https://cdn.morpho.org/v2/assets/images/bprotocol.png",
-    "name": "B.Protocol",
     "url": "https://www.bprotocol.org/",
     "verified": true,
     "addresses": {
@@ -75,15 +68,13 @@
       ],
       "8453": [
         "0x4b8f6CADb8A2B222e8840E8aDDc32E031794A4D6",
-        "0x8b621804a7637b781e2BbD58e256a591F2dF7d51",
         "0x32f75c3ee6aD872Eb3138020885E94E2842b8433"
       ]
     }
   },
   {
     "image": "https://cdn.morpho.org/v2/assets/images/re7.png",
-    "name": "RE7 Labs",
-    "url": "https://www.re7.capital",
+    "url": "https://www.re7labs.xyz/",
     "verified": true,
     "addresses": {
       "1": ["0xE86399fE6d7007FdEcb08A2ee1434Ee677a04433"],
@@ -100,7 +91,7 @@
   {
     "image": "https://cdn.morpho.org/v2/assets/images/steakhouse.svg",
     "name": "Steakhouse Financial",
-    "url": "https://www.steakhouse.financial/projects/risk-management-framework-for-defi-protocols",
+    "url": "https://www.steakhouse.financial",
     "verified": true,
     "addresses": {
       "1": [

--- a/data/curators-whitelist.json
+++ b/data/curators-whitelist.json
@@ -59,6 +59,7 @@
   {
     "image": "https://cdn.morpho.org/v2/assets/images/bprotocol.png",
     "url": "https://www.bprotocol.org/",
+    "name": "B.Protocol",
     "verified": true,
     "addresses": {
       "1": [
@@ -74,6 +75,7 @@
   },
   {
     "image": "https://cdn.morpho.org/v2/assets/images/re7.png",
+    "name": "RE7 Labs",
     "url": "https://www.re7labs.xyz/",
     "verified": true,
     "addresses": {
@@ -123,7 +125,7 @@
     }
   },
   {
-    "image": "https://cdn.morpho.org/assets/logos/crvusd.svg",
+    "image": "https://cdn.morpho.org/v2/assets/images/llamarisk.svg",
     "name": "LlamaRisk",
     "url": "https://www.llamarisk.com/",
     "verified": true,

--- a/test/json/validation/curators.test.ts
+++ b/test/json/validation/curators.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "@jest/globals";
+import { loadJsonFile } from "../../utils/jsonValidators";
+import { getAddress } from "viem";
+
+interface CuratorAddresses {
+  [chainId: string]: string[];
+}
+
+interface Curator {
+  image: string;
+  name: string;
+  url: string;
+  verified: boolean;
+  addresses: CuratorAddresses;
+}
+
+describe("curators-whitelist.json validation", () => {
+  const curators = loadJsonFile("curators-whitelist.json") as Curator[];
+
+  test("curator names are unique", () => {
+    const names = new Set<string>();
+    const duplicates: string[] = [];
+
+    curators.forEach((curator) => {
+      if (names.has(curator.name)) {
+        duplicates.push(curator.name);
+      }
+      names.add(curator.name);
+    });
+
+    if (duplicates.length > 0) {
+      throw new Error(
+        `Found duplicate curator names: ${duplicates.join(", ")}`
+      );
+    }
+  });
+
+  test("image URLs are valid", () => {
+    const errors: string[] = [];
+    const baseUrl = "https://cdn.morpho.org/v2/assets/images";
+
+    curators.forEach((curator) => {
+      if (!curator.image || curator.image === "") {
+        errors.push(`Empty image URL for curator: ${curator.name}`);
+      } else if (!curator.image.startsWith(baseUrl)) {
+        errors.push(
+          `Invalid image URL for curator ${curator.name}: ${curator.image}. Must start with ${baseUrl}`
+        );
+      }
+    });
+
+    if (errors.length > 0) {
+      throw new Error(`Found image URL errors:\n${errors.join("\n")}`);
+    }
+  });
+
+  test("verified field is true", () => {
+    const errors: string[] = [];
+
+    curators.forEach((curator) => {
+      if (curator.verified !== true) {
+        errors.push(`Curator ${curator.name} must have verified: true`);
+      }
+    });
+
+    if (errors.length > 0) {
+      throw new Error(`Found verification errors:\n${errors.join("\n")}`);
+    }
+  });
+
+  test("chain IDs are valid (1 or 8453)", () => {
+    const validChainIds = ["1", "8453"];
+    const errors: string[] = [];
+
+    curators.forEach((curator) => {
+      Object.keys(curator.addresses).forEach((chainId) => {
+        if (!validChainIds.includes(chainId)) {
+          errors.push(
+            `Invalid chain ID ${chainId} for curator ${curator.name}`
+          );
+        }
+      });
+    });
+
+    if (errors.length > 0) {
+      throw new Error(
+        `Found chain ID validation errors:\n${errors.join("\n")}`
+      );
+    }
+  });
+
+  test("addresses are checksummed", () => {
+    const errors: string[] = [];
+
+    curators.forEach((curator) => {
+      Object.entries(curator.addresses).forEach(([chainId, addresses]) => {
+        addresses.forEach((address) => {
+          try {
+            const checksummedAddress = getAddress(address);
+            if (address !== checksummedAddress) {
+              errors.push(
+                `Invalid checksum for address ${address} (curator: ${curator.name}, chain: ${chainId}). Should be ${checksummedAddress}`
+              );
+            }
+          } catch (error) {
+            errors.push(
+              `Invalid address format: ${address} (curator: ${curator.name}, chain: ${chainId})`
+            );
+          }
+        });
+      });
+    });
+
+    if (errors.length > 0) {
+      throw new Error(`Found address validation errors:\n${errors.join("\n")}`);
+    }
+  });
+});


### PR DESCRIPTION
Crefuly read the readme please.

This PR is matching [this one](https://github.com/morpho-org/morpho-blue-api/pull/850) on `blue-api`

## Idea
The idea is to automatically connect vaults to curators based on curator  and owner  of the vault. Curators can be whitelisted using the curators-whitelist.json  file, listing all the known addresses connected to a specific curator.

## Whitelist
The current whitelist has been generated using this script (and removing test values):

```ts
import { zeroAddress } from "viem";
import vaults from "./vaults.json" assert { type: "json" }; // result of the following queries
import { writeFileSync } from "fs";
import { initDir } from "../../src/files.js";
import { values } from "@morpho-org/morpho-ts";

interface CuratorWhitelisting {
  name: string;
  image?: string;
  url?: string;
  verified: boolean;
  addresses: {
    [chain in number]?: Set<string>;
  };
}

const CURATORS = {} as Record<string, CuratorWhitelisting>;

vaults.data.vaults.items.forEach((vault) => {
  vault.metadata?.curators.forEach((curator) => {
    const chainAddresses = ((CURATORS[curator.name] ??= {
      ...curator,
      addresses: {},
    }).addresses[vault.chain.id] ??= new Set());

    if (vault.state.curator !== zeroAddress)
      chainAddresses.add(vault.state.curator);
    if (vault.state.owner !== zeroAddress)
      chainAddresses.add(vault.state.owner);
  });
});

//@ts-expect-error
Set.prototype.toJSON = function (this) {
  return [...this];
};

writeFileSync(
  BASE_DIR + "/curators-whitelisting.json",
  JSON.stringify(values(CURATORS))
);
```

query: 

```gql
query VaultByAddress {
  vaults {items {
    chain {
      id
    }
    metadata {
      curators {
        image
        name
        verified
        url
      }
    }
    state {
      owner
      curator
    }
  }}
}
```