### PR TITLE
feat(USR & RLP): whitelisting feeds + pricing tokens + tokens logos

### DIFF
--- a/data/oracle-prices.json
+++ b/data/oracle-prices.json
@@ -2656,6 +2656,15 @@
     "contractChainId": 1
   },
   {
+    "assetAddress": "0xC31389794Ffac23331E0D9F611b7953f90AA5fDC",
+    "contractAddress": "0x9924a529d15067518Bf5182202BfAd71E4B64a74",
+    "order": 0,
+    "type": "pyth_network",
+    "data": "{\"decimals\": 8, \"first_block_number\": 26668888}",
+    "assetChainId": 8453,
+    "contractChainId": 8453
+  },
+  {
     "assetAddress": "0x66a1E37c9b0eAddca17d3662D6c05F4DECf3e110",
     "contractAddress": "0xf9C7c25FE58AAA494EE7ff1f6Cf0b70d7C7ce88c",
     "order": 0,
@@ -2663,6 +2672,15 @@
     "data": "{\"decimals\": 8, \"first_block_number\": 21564013}",
     "assetChainId": 1,
     "contractChainId": 1
+  },
+  {
+    "assetAddress": "0x35E5dB674D8e93a03d814FA0ADa70731efe8a4b9",
+    "contractAddress": "0x19feFdd35B67C2694F3532a8e0Be75dFf0f8bFBb",
+    "order": 0,
+    "type": "pyth_network",
+    "data": "{\"decimals\": 8, \"first_block_number\": 26668888}",
+    "assetChainId": 8453,
+    "contractChainId": 8453
   },
   {
     "assetAddress": "0x1202F5C7b4B9E47a1A484E8B270be34dbbC75055",

--- a/data/price-feeds.json
+++ b/data/price-feeds.json
@@ -5048,6 +5048,36 @@
     }
   },
   {
+    "chainId": 8453,
+    "address": "0x19feFdd35B67C2694F3532a8e0Be75dFf0f8bFBb",
+    "vendor": "Pyth Network",
+    "description": "USR / USD",
+    "pair": ["USR", "USD"],
+    "tokenIn": {
+      "address": "0x35E5dB674D8e93a03d814FA0ADa70731efe8a4b9",
+      "chainId": 8453
+    },
+    "tokenOut": {
+      "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+      "chainId": 8453
+    }
+  },
+  {
+    "chainId": 8453,
+    "address": "0xCd76c50c3210C5AaA9c39D53A4f95BFd8b1a3a19",
+    "vendor": "Pyth Network",
+    "description": "USR / USD",
+    "pair": ["USR", "USD"],
+    "tokenIn": {
+      "address": "0x35E5dB674D8e93a03d814FA0ADa70731efe8a4b9",
+      "chainId": 8453
+    },
+    "tokenOut": {
+      "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+      "chainId": 8453
+    }
+  },
+  {
     "chainId": 1,
     "address": "0xAdb2c15Fde49D1A4294740aCb650de94184E66b2",
     "vendor": "Resolv",
@@ -5060,6 +5090,21 @@
     "tokenOut": {
       "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
       "chainId": 1
+    }
+  },
+  {
+    "chainId": 8453,
+    "address": "0x9924a529d15067518Bf5182202BfAd71E4B64a74",
+    "vendor": "Pyth Network",
+    "description": "RLP / USD",
+    "pair": ["RLP", "USD"],
+    "tokenIn": {
+      "address": "0xC31389794Ffac23331E0D9F611b7953f90AA5fDC",
+      "chainId": 8453
+    },
+    "tokenOut": {
+      "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+      "chainId": 8453
     }
   },
   {

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -1706,6 +1706,18 @@
     "isWhitelisted": true
   },
   {
+    "chainId": 8453,
+    "address": "0xC31389794Ffac23331E0D9F611b7953f90AA5fDC",
+    "name": "Resolv Liquidity Provider Token",
+    "symbol": "RLP",
+    "decimals": 18,
+    "metadata": {
+      "logoURI": "https://cdn.morpho.org/assets/logos/rlp.svg",
+      "alternativeHardcodedOracles": ["USDC", "USD"]
+    },
+    "isWhitelisted": true
+  },
+  {
     "chainId": 1,
     "address": "0xA8c8861b5ccF8CCe0ade6811CD2A7A7d3222B0B8",
     "name": "PT Wrapped stUSR 27MAR2025",
@@ -1725,6 +1737,19 @@
     "metadata": {
       "logoURI": "https://cdn.morpho.org/assets/logos/usr.svg",
       "alternativeHardcodedOracles": ["USDC"],
+      "tags": ["stablecoin", "usd-pegged"]
+    },
+    "isWhitelisted": true
+  },
+  {
+    "chainId": 8453,
+    "address": "0x35E5dB674D8e93a03d814FA0ADa70731efe8a4b9",
+    "name": "Resolv USD",
+    "symbol": "USR",
+    "decimals": 18,
+    "metadata": {
+      "logoURI": "https://cdn.morpho.org/assets/logos/usr.svg",
+      "alternativeHardcodedOracles": ["USDC", "USD"],
       "tags": ["stablecoin", "usd-pegged"]
     },
     "isWhitelisted": true


### PR DESCRIPTION
fixes INTEG-1643
fixes INTEG-1642
fixes INTEG-1630

As weird as it may sound, both price feed for USR/USD points to the same pythID. Both seems legit, a message has been sent to pyth for clarification, but we can proceed

Pyth Verif:

It has to be done at this level:
![image](https://github.com/user-attachments/assets/b32f4f24-a8e8-4791-b64d-530f42ab434e)

https://www.pyth.network/price-feeds/crypto-usr-usd-rr
![image](https://github.com/user-attachments/assets/3432ff41-0e78-41c3-a5a8-f465a3a94fb8)
