### PR TITLE
fix(tokens): add DAI USD alternative price

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -1870,7 +1870,7 @@
     "metadata": {
       "logoURI": "https://cdn.morpho.org/assets/logos/dai.svg",
       "tags": ["stablecoin", "usd-pegged", "dai-specific-permit"],
-      "alternativeHardcodedOracles": ["USDS"]
+      "alternativeHardcodedOracles": ["USDS", "USD"]
     },
     "isWhitelisted": true
   },


### PR DESCRIPTION
It will remove the red warning on DAI - USD hardcoded markets
<img width="1390" alt="image" src="https://github.com/user-attachments/assets/b6b2ca5e-992b-4d90-86e8-6cc8e2a4cb28" />
