### PR TITLE
feat(pt-teth): pricing, whitelisting the pt-token

### DIFF
--- a/data/oracle-prices.json
+++ b/data/oracle-prices.json
@@ -117,6 +117,24 @@
     "contractChainId": 1
   },
   {
+    "assetAddress": "0x84D17Ef6BeC165484c320B852eEB294203e191be",
+    "contractAddress": "0xBDb8F9729d3194f75fD1A3D9bc4FFe0DDe3A404c",
+    "order": 0,
+    "type": "pendle_asset_rate",
+    "data": "{\"decimals\": 18, \"first_block_number\": 21922406}",
+    "assetChainId": 1,
+    "contractChainId": 1
+  },
+  {
+    "assetAddress": "0x84D17Ef6BeC165484c320B852eEB294203e191be",
+    "contractAddress": "0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8",
+    "order": 1,
+    "type": "chainlink_aggregator",
+    "data": "{\"decimals\": 8, \"first_block_number\": 21922406}",
+    "assetChainId": 1,
+    "contractChainId": 1
+  },
+  {
     "assetAddress": "0xE08C45F3cfE70f4e03668Dc6E84Af842bEE95A68",
     "contractAddress": "0xfD482179DdEe989C45eaB19991852F80fF31457a",
     "order": 0,

--- a/data/price-feeds.json
+++ b/data/price-feeds.json
@@ -5222,5 +5222,20 @@
       "address": "0x66a1E37c9b0eAddca17d3662D6c05F4DECf3e110",
       "chainId": 1
     }
+  },
+  {
+    "chainId": 1,
+    "address": "0x427b2AFe58615043D460110d1a86D41446530352",
+    "vendor": "Pendle",
+    "description": "PT-tETH 29 MAY 2025 PtToSyRate adapter x tETH/wstETH oracle",
+    "pair": ["PT-tETH-29MAY2025", "wstETH"],
+    "tokenIn": {
+      "address": "0x84D17Ef6BeC165484c320B852eEB294203e191be",
+      "chainId": 1
+    },
+    "tokenOut": {
+      "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+      "chainId": 1
+    }
   }
 ]

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -2266,5 +2266,16 @@
       "logoURI": "https://cdn.morpho.org/assets/logos/well.svg"
     },
     "isWhitelisted": true
+  },
+  {
+    "chainId": 1,
+    "address": "0x84D17Ef6BeC165484c320B852eEB294203e191be",
+    "name": "PT Treehouse ETH 29MAY2025",
+    "symbol": "PT-tETH-29MAY2025",
+    "decimals": 18,
+    "metadata": {
+      "logoURI": "https://cdn.morpho.org/assets/logos/pt-teth-29may2025.svg"
+    },
+    "isWhitelisted": true
   }
 ]


### PR DESCRIPTION
Pricing:
1. PT-tETH -> stETH at maturity (according to pendle https://app.pendle.finance/trade/markets/0xbdb8f9729d3194f75fd1a3d9bc4ffe0dde3a404c/swap?view=pt&chain=ethereum&tab=info)
0xBDb8F9729d3194f75fD1A3D9bc4FFe0DDe3A404c: 

2. stETH/USD chainlink


Otherwise about this:
0x427b2AFe58615043D460110d1a86D41446530352
the desc is the one on the contract