### PR TITLE
feat(spectra): pricing and supporting spectra asset

### DIFF
--- a/data/oracle-prices.json
+++ b/data/oracle-prices.json
@@ -2798,5 +2798,32 @@
     "data": "{\"decimals\": 8, \"first_block_number\": 21929060}",
     "assetChainId": 1,
     "contractChainId": 1
+  },
+  {
+    "assetAddress": "0x2a8c22E3b10036f3AEF5875d04f8441d4188b656",
+    "contractAddress": "0xE4f2AE539442e1D3Fb40F03ceEbF4A372a390d24",
+    "order": 0,
+    "type": "redstone_without_logs",
+    "data": "{\"decimals\": 8, \"first_block_number\": 21929124}",
+    "assetChainId": 1,
+    "contractChainId": 1
+  },
+  {
+    "assetAddress": "0x1C2757c1FeF1038428b5bEF062495ce94BBe92b2",
+    "contractAddress": "0x6d62D3C3C8f9912890788b50299bF4D2C64823b6",
+    "order": 0,
+    "type": "redstone_without_logs",
+    "data": "{\"decimals\": 8, \"first_block_number\": 21929124}",
+    "assetChainId": 8453,
+    "contractChainId": 8453
+  },
+  {
+    "assetAddress": "0xbB51E2a15A9158EBE2b0Ceb8678511e063AB7a55",
+    "contractAddress": "0x698dA5D987a71b68EbF30C1555cfd38F190406b7",
+    "order": 0,
+    "type": "redstone_without_logs",
+    "data": "{\"decimals\": 8, \"first_block_number\": 21929124}",
+    "assetChainId": 1,
+    "contractChainId": 1
   }
 ]

--- a/data/oracle-prices.json
+++ b/data/oracle-prices.json
@@ -2780,5 +2780,23 @@
     "data": "{\"decimals\": 6, \"usd_value\": 1000000, \"first_block_number\": 21587702}",
     "assetChainId": 1,
     "contractChainId": 1
+  },
+  {
+    "assetAddress": "0xb4B8925c4CBce692F37C9D946883f2E330a042a9",
+    "contractAddress": "0x54AedFe96cB7724fA59Ba7666679C2002E10B8bc",
+    "order": 0,
+    "type": "redstone_without_logs",
+    "data": "{\"decimals\": 18, \"first_block_number\": 21929060}",
+    "assetChainId": 1,
+    "contractChainId": 1
+  },
+  {
+    "assetAddress": "0xb4B8925c4CBce692F37C9D946883f2E330a042a9",
+    "contractAddress": "0xcA727511c9d542AAb9eF406d24E5bbbE4567c22d",
+    "order": 1,
+    "type": "redstone_without_logs",
+    "data": "{\"decimals\": 8, \"first_block_number\": 21929060}",
+    "assetChainId": 1,
+    "contractChainId": 1
   }
 ]

--- a/data/price-feeds.json
+++ b/data/price-feeds.json
@@ -328,6 +328,28 @@
   },
   {
     "chainId": 1,
+    "address": "0x54AedFe96cB7724fA59Ba7666679C2002E10B8bc",
+    "vendor": "Spectra",
+    "description": "SpectraPriceOracle ",
+    "pair": ["PT-sdeUSD-1753142406", "deUSD"],
+    "tokenOut": {
+      "address": "0x15700B564Ca08D9439C58cA5053166E8317aa138",
+      "chainId": 1
+    }
+  },
+  {
+    "chainId": 1,
+    "address": "0x72caFFcdE0cf1813596f7DF7B50217E1753c5872",
+    "vendor": "Spectra",
+    "description": "Spectra 22JULY2025 PT-sdeUSD/USD ",
+    "pair": ["PT-sdeUSD-1753142406", "USD"],
+    "tokenOut": {
+      "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+      "chainId": 1
+    }
+  },
+  {
+    "chainId": 1,
     "address": "0xcA727511c9d542AAb9eF406d24E5bbbE4567c22d",
     "vendor": "Redstone",
     "description": "deUSD/USD (0.2%)",

--- a/data/price-feeds.json
+++ b/data/price-feeds.json
@@ -4839,6 +4839,21 @@
   },
   {
     "chainId": 1,
+    "address": "0x698dA5D987a71b68EbF30C1555cfd38F190406b7",
+    "vendor": "Midas",
+    "description": "mEDGE / USD price feed",
+    "pair": ["mEDGE", "USD"],
+    "tokenIn": {
+      "address": "0xbB51E2a15A9158EBE2b0Ceb8678511e063AB7a55",
+      "chainId": 1
+    },
+    "tokenOut": {
+      "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+      "chainId": 1
+    }
+  },
+  {
+    "chainId": 1,
     "address": "0xA663B02CF0a4b149d2aD41910CB81e23e1c41c32",
     "vendor": "Frax",
     "description": "sFRAX / FRAX exchange rate",

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -522,6 +522,18 @@
   },
   {
     "chainId": 1,
+    "address": "0xbB51E2a15A9158EBE2b0Ceb8678511e063AB7a55",
+    "name": "Midas mEDGE",
+    "symbol": "mEDGE",
+    "decimals": 18,
+    "metadata": {
+      "logoURI": "https://cdn.morpho.org/assets/logos/medge.svg",
+      "tags": ["yield", "rwa"]
+    },
+    "isWhitelisted": true
+  },
+  {
+    "chainId": 1,
     "address": "0xf1C9acDc66974dFB6dEcB12aA385b9cD01190E38",
     "name": "Staked ETH",
     "symbol": "osETH",

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -2277,5 +2277,16 @@
       "logoURI": "https://cdn.morpho.org/assets/logos/pt-teth-29may2025.svg"
     },
     "isWhitelisted": true
+  },
+  {
+    "chainId": 1,
+    "address": "0xb4B8925c4CBce692F37C9D946883f2E330a042a9",
+    "name": "Principal Token: sdeUSD-1753142406",
+    "symbol": "PT-sdeUSD-1753142406",
+    "decimals": 18,
+    "metadata": {
+      "logoURI": "https://cdn.morpho.org/assets/logos/pt-sdeusd-1753142406.svg"
+    },
+    "isWhitelisted": true
   }
 ]

--- a/data/vaults-whitelist.json
+++ b/data/vaults-whitelist.json
@@ -233,6 +233,10 @@
       {
         "action": "added",
         "timestamp": 1727439009
+      },
+      {
+        "action": "removed",
+        "timestamp": 1740557903
       }
     ]
   },

--- a/docs/pricing/oracle-prices.md
+++ b/docs/pricing/oracle-prices.md
@@ -277,3 +277,12 @@ Here are the entries required to add an oracle price for `wstETH` on ETH mainnet
   }
 ]
 ```
+
+## Technical Debt:
+
+Some asset are not supported by the current oracle types. By defualt the type Redstone_without_logs stilla llow the pricing of them, as it simply query the `latestRoundData` method.
+
+Exhaustive list of assets that are not supported:
+
+1. 0xb4B8925c4CBce692F37C9D946883f2E330a042a9 // PT-sdeUSD-1753142406 - Spectra
+2.

--- a/docs/pricing/oracle-prices.md
+++ b/docs/pricing/oracle-prices.md
@@ -284,5 +284,7 @@ Some asset are not supported by the current oracle types. By defualt the type Re
 
 Exhaustive list of assets that are not supported:
 
-1. 0xb4B8925c4CBce692F37C9D946883f2E330a042a9 // PT-sdeUSD-1753142406 - Spectra
-2.
+1. 0xb4B8925c4CBce692F37C9D946883f2E330a042a9 // PT-sdeUSD-1753142406 - Spectra - Mainnet
+2. 0x2a8c22E3b10036f3AEF5875d04f8441d4188b656 // mBASIS - Midas - Mainnet
+3. 0x1C2757c1FeF1038428b5bEF062495ce94BBe92b2 // mBASIS - Midas - Base
+4. 0xbB51E2a15A9158EBE2b0Ceb8678511e063AB7a55 // mEDGE - Midas - Mainnet

--- a/docs/pricing/oracle-prices.md
+++ b/docs/pricing/oracle-prices.md
@@ -280,7 +280,7 @@ Here are the entries required to add an oracle price for `wstETH` on ETH mainnet
 
 ## Technical Debt:
 
-Some asset are not supported by the current oracle types. By defualt the type Redstone_without_logs stilla llow the pricing of them, as it simply query the `latestRoundData` method.
+Some assets are not supported by the current oracle types. By default the type Redstone_without_logs still allows the pricing of them, as it simply queries the `latestRoundData` method.
 
 Exhaustive list of assets that are not supported:
 


### PR DESCRIPTION
- also fixes INTEG-1659
- + price mBASIS & mEDGE with "redstone without logs" type. Warning, it is just because the midas type is not accepted (technical debt). in practice, it reads properly the latestRoundData.
- also removes the old USD0 vault from the EARN section as requested by MEV Cap.

