### PR TITLE
fix(feeds): wrong decimals defined

### DIFF
--- a/data/price-feeds.json
+++ b/data/price-feeds.json
@@ -3215,7 +3215,7 @@
       "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
       "chainId": 1
     },
-    "decimals": 8
+    "decimals": 18
   },
   {
     "chainId": 1,


### PR DESCRIPTION
0xdeb288F737066589598e9214E782fa5A8eD689e8 has 18 decimals