### PR TITLE
feat(rUSD):hardcoding to USDC

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -1596,7 +1596,8 @@
     "decimals": 18,
     "metadata": {
       "logoURI": "https://cdn.morpho.org/assets/logos/rusd.svg",
-      "alternativeHardcodedOracles": ["USD", "usd-pegged", "rwa"]
+      "alternativeHardcodedOracles": ["USD", "USDC"],
+      "tags": ["stablecoin", "usd-pegged", "rwa"]
     },
     "isWhitelisted": true
   },


### PR DESCRIPTION
Hardcoding rUSD to USDC on mainnet and moving out tags from the `alternativeHardcodedOracles` section