### PR TITLE
feat(USDO): hardcoding to USDC

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -2428,7 +2428,7 @@
     "metadata": {
       "logoURI": "https://cdn.morpho.org/assets/logos/usdo.svg",
       "tags": ["stable", "usd"],
-      "alternativeHardcodedOracles": ["USD"]
+      "alternativeHardcodedOracles": ["USD", "USDC"]
     },
     "isWhitelisted": true
   },


### PR DESCRIPTION
Removing warning from cUSDO/USDC (https://app.morpho.org/base/market/0x99f294c452edc091c988688d501dca78a06ba559065c242b19653452e6affc7a/cusdo-usdc)

by hardcoding USDO to USDC

Clearstar Labs request

FIXES INTEG-1965