### PR TITLE
feat(markets):process 3 markets

### DIFF
--- a/data/oracle-prices.json
+++ b/data/oracle-prices.json
@@ -3060,5 +3060,23 @@
     "data": "{\"decimals\": 18, \"usd_value\": 1000000000000000000, \"first_block_number\": 22181834}",
     "assetChainId": 1,
     "contractChainId": 1
+  },
+  {
+    "assetAddress": "0x4ae0154F83427A5864e5de6513a47dAC9E5D5a69",
+    "contractAddress": "0x0271e2d3529314837B84407148bEE5cFbf37689D",
+    "order": 0,
+    "type": "redstone_without_logs",
+    "data": "{\"decimals\": 18, \"first_block_number\": 22223117}",
+    "assetChainId": 1,
+    "contractChainId": 1
+  },
+  {
+    "assetAddress": "0x4ae0154F83427A5864e5de6513a47dAC9E5D5a69",
+    "contractAddress": "0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8",
+    "order": 1,
+    "type": "chainlink_aggregator",
+    "data": "{\"decimals\": 8, \"first_block_number\": 22223117}",
+    "assetChainId": 1,
+    "contractChainId": 1
   }
 ]

--- a/data/oracle-vaults.json
+++ b/data/oracle-vaults.json
@@ -172,5 +172,11 @@
     "vendor": "Falcon Finance",
     "chainId": 1,
     "pair": ["sUSDf", "USDf"]
+  },
+  {
+    "address": "0x1CE7D9942ff78c328A4181b9F3826fEE6D845A97",
+    "vendor": "YieldFi",
+    "chainId": 1,
+    "pair": ["yUSD", "sUSD"]
   }
 ]

--- a/data/price-feeds.json
+++ b/data/price-feeds.json
@@ -5627,5 +5627,35 @@
       "address": "0x4200000000000000000000000000000000000006",
       "chainId": 8453
     }
+  },
+  {
+    "chainId": 1,
+    "address": "0x0271e2d3529314837B84407148bEE5cFbf37689D",
+    "vendor": "eOracle",
+    "description": "PT-inwstETHs/stETH",
+    "pair": ["PT-sw-inwstETHs-1752969615", "stETH"],
+    "tokenIn": {
+      "address": "0x4ae0154F83427A5864e5de6513a47dAC9E5D5a69",
+      "chainId": 1
+    },
+    "tokenOut": {
+      "address": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+      "chainId": 1
+    }
+  },
+  {
+    "chainId": 1,
+    "address": "0xBb54D319D989296E3bC8f5373c89a2C943aeC41B",
+    "vendor": "eOracle",
+    "description": "mMEV/USD Adapter",
+    "pair": ["mMEV", "USD"],
+    "tokenIn": {
+      "address": "0x030b69280892c888670EDCDCD8B69Fd8026A0BF3",
+      "chainId": 1
+    },
+    "tokenOut": {
+      "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+      "chainId": 1
+    }
   }
 ]

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -2652,5 +2652,28 @@
       "tags": ["yield"]
     },
     "isWhitelisted": true
+  },
+  {
+    "chainId": 1,
+    "address": "0x1CE7D9942ff78c328A4181b9F3826fEE6D845A97",
+    "name": "YieldFi yToken",
+    "symbol": "yUSD",
+    "decimals": 18,
+    "metadata": {
+      "logoURI": "https://cdn.morpho.org/assets/logos/yusd.svg",
+      "tags": ["yield"]
+    },
+    "isWhitelisted": true
+  },
+  {
+    "chainId": 1,
+    "address": "0x4ae0154F83427A5864e5de6513a47dAC9E5D5a69",
+    "name": "Principal Token: sw-inwstETHs-1752969615",
+    "symbol": "PT-sw-inwstETHs-1752969615",
+    "decimals": 18,
+    "metadata": {
+      "logoURI": "https://cdn.morpho.org/assets/logos/pt-sw-inwsteths-1752969615.svg"
+    },
+    "isWhitelisted": true
   }
 ]

--- a/docs/pricing/oracle-prices.md
+++ b/docs/pricing/oracle-prices.md
@@ -299,3 +299,4 @@ Exhaustive list of assets that are not supported:
 13. 0xae4bE3acD95B6a4Ac5A0524ab95dA90c721f6C83 // PT-USR-29MAY2025 - mainnet
 14. 0x23E60d1488525bf4685f53b3aa8E676c30321066 // PT-wstUSR-25SEP2025 - mainnet
 15. 0x4A977653c58CFD82d42fd706cf68A0c1B6d0ca56 // PT-wstUSR-1750896030 - Spectra - Mainnet
+16. 0x4ae0154F83427A5864e5de6513a47dAC9E5D5a69 // PT-sw-inwstETHs-1752969615 - Spectra - Mainnet


### PR DESCRIPTION
**FIXES INTEG-2119**
[yUSD/USDC](https://app.morpho.org/ethereum/market/0x1c06f86ff1fe0f46937b13a6a489aa4f44e8f4b23fc5ed63f65d7381ad22267c/yusd-usdc)
WL exchange rate and asset
yUSD already priced on API. didn't add a pricing method (to validate)

**FIXES INTEG-2120**
[PT-sw-inwstETHs-1752969615/WETH](https://app.morpho.org/ethereum/market/0x6564018d0239d8072ccac53f556d661bec29f81c023e3aff2aeb961f25108d04/pt-sw-inwsteths-1752969615-weth)
WL eOracle feed and asset + redstone_without_logs pricing

**FIXES INTEG-2121**
[mMEV/USR](https://app.morpho.org/ethereum/market/0x4987abb1971947da9be3a47a58cb846a57b8a33bb3db1b0b2c6a3599c8b3a576/mmev-usr)
Asset already WL and priced in the API (not via metadata)
WL eOracle feed