### PR TITLE
feat(warning):hardcoding sUSD-USDC

### DIFF
--- a/data/price-feeds.json
+++ b/data/price-feeds.json
@@ -5484,7 +5484,15 @@
     "address": "0x84e51A0c8DAc953F37bc72A43Fd3a008345efCB8",
     "vendor": "Steakhouse",
     "description": "wUSDL / USDL feed",
-    "pair": ["wUSDL", "USDL"]
+    "pair": ["wUSDL", "USDL"],
+    "tokenIn": {
+      "address": "0x7751E2F4b8ae93EF6B79d86419d42FE3295A4559",
+      "chainId": 1
+    },
+    "tokenOut": {
+      "address": "0xbdC7c08592Ee4aa51D06C27Ee23D5087D65aDbcD",
+      "chainId": 1
+    }
   },
   {
     "chainId": 8453,

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -2675,5 +2675,16 @@
       "logoURI": "https://cdn.morpho.org/assets/logos/pt-sw-inwsteths-1752969615.svg"
     },
     "isWhitelisted": true
+  },
+  {
+    "chainId": 1,
+    "address": "0x4F8E1426A9d10bddc11d26042ad270F16cCb95F2",
+    "name": "YieldFi Stable Token",
+    "symbol": "sUSD",
+    "decimals": 18,
+    "metadata": {
+      "alternativeHardcodedOracles": ["USDC"]
+    },
+    "isWhitelisted": false
   }
 ]


### PR DESCRIPTION
**Remove warning on [yUSD/USDC](https://app.morpho.org/ethereum/market/0x1c06f86ff1fe0f46937b13a6a489aa4f44e8f4b23fc5ed63f65d7381ad22267c/yusd-usdc)**
no logo nor whitelist.

**Remove warning on [csUSDL/USDC](https://app.morpho.org/ethereum/market/0x83b7ad16905809ea36482f4fbf6cfee9c9f316d128de9a5da1952607d5e4df5e/csusdl-usdc) - FIXES INTEG-2118**
By adding more info on the existing feed.