### PR TITLE
feat(steakhouse): whitelisting market and oracle for syrup and lvl

### DIFF
--- a/data/oracle-vaults.json
+++ b/data/oracle-vaults.json
@@ -184,5 +184,11 @@
     "vendor": "YieldFi",
     "chainId": 1,
     "pair": ["yUSD", "sUSD"]
+  },
+  {
+    "address": "0x4737D9b4592B40d51e110b94c9C043c6654067Ae",
+    "vendor": "Level",
+    "chainId": 1,
+    "pair": ["slvlUSD", "lvlUSD"]
   }
 ]

--- a/data/price-feeds.json
+++ b/data/price-feeds.json
@@ -5313,6 +5313,13 @@
   },
   {
     "chainId": 1,
+    "address": "0xC0f7CF02022faea87b18C77425D9ab14c20C6DB9",
+    "vendor": "Pendle",
+    "description": "PT-syrupUSDC-28AUG2025 - USDC pendle price adapter",
+    "pair": ["PT-syrupUSDC-28AUG2025", "USDC"]
+  },
+  {
+    "chainId": 1,
     "address": "0xB2b3524A0a7145b59E4146a4BaE35A5dB2842508",
     "vendor": "Pendle",
     "description": "eOracle PT-wstUSR-25SEP2025/USR (PtToSyRate TWAP)",

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -615,6 +615,17 @@
   },
   {
     "chainId": 1,
+    "address": "0xCcE7D12f683c6dAe700154f0BAdf779C0bA1F89A",
+    "name": "PT Syrup USDC 28AUG2025",
+    "symbol": "PT-syrupUSDC-28AUG2025",
+    "decimals": 6,
+    "metadata": {
+      "logoURI": "https://cdn.morpho.org/assets/logos/pt-syrupusdc.svg"
+    },
+    "isWhitelisted": true
+  },
+  {
+    "chainId": 1,
     "address": "0x643C4E15d7d62Ad0aBeC4a9BD4b001aA3Ef52d66",
     "name": "Syrup Token",
     "symbol": "SYRUP",
@@ -2775,6 +2786,17 @@
     "decimals": 18,
     "metadata": {
       "logoURI": "https://cdn.morpho.org/assets/logos/pt-slvlusd.svg"
+    },
+    "isWhitelisted": true
+  },
+  {
+    "chainId": 1,
+    "address": "0x4737D9b4592B40d51e110b94c9C043c6654067Ae",
+    "name": "Staked lvlUSD",
+    "symbol": "slvlUSD",
+    "decimals": 18,
+    "metadata": {
+      "logoURI": "https://cdn.morpho.org/assets/logos/slvlusd.svg"
     },
     "isWhitelisted": true
   },


### PR DESCRIPTION
fixes INTEG-2177
fixes INTEG-2187
fixes INTEG-2188

FYI: 1 
PT syrupUSDC
is equal to 1 USDC staked in Syrup.Fi at maturity
https://app.pendle.finance/trade/markets/0x9a63fa80b5ddfd3cab23803fdb93ad2c18f3d5aa/swap?view=pt&chain=ethereum