### PR TITLE
Feat/add curators metadata

### DIFF
--- a/data/curators-whitelist.json
+++ b/data/curators-whitelist.json
@@ -2,6 +2,7 @@
   {
     "image": "https://cdn.morpho.org/v2/assets/images/mevcapital.png",
     "name": "MEV Capital",
+    "url": "https://mevcapital.com/",
     "verified": true,
     "addresses": {
       "1": [
@@ -18,15 +19,14 @@
   {
     "image": "https://cdn.morpho.org/v2/assets/images/gauntlet.svg",
     "name": "Gauntlet",
+    "url": "https://www.gauntlet.xyz/",
     "verified": true,
     "addresses": {
       "1": [
         "0x9E33faAE38ff641094fa68c65c2cE600b3410585",
         "0xC684c6587712e5E7BDf9fD64415F23Bd2b05fAec"
       ],
-      "137": [
-        "0x9E33faAE38ff641094fa68c65c2cE600b3410585"
-      ],
+      "137": ["0x9E33faAE38ff641094fa68c65c2cE600b3410585"],
       "8453": [
         "0x9E33faAE38ff641094fa68c65c2cE600b3410585",
         "0x5a4E19842e09000a582c20A4f524C26Fb48Dd4D0"
@@ -40,6 +40,7 @@
   {
     "image": "https://cdn.morpho.org/v2/assets/images/9summits.png",
     "name": "9Summits",
+    "url": "https://9summits.io/",
     "verified": true,
     "addresses": {
       "1": [
@@ -61,6 +62,7 @@
   {
     "image": "https://cdn.morpho.org/v2/assets/images/tulipa-capital.svg",
     "name": "Tulipa Capital",
+    "url": "https://www.tulipa.capital/",
     "verified": true,
     "addresses": {
       "1": [
@@ -76,15 +78,14 @@
   {
     "image": "https://cdn.morpho.org/v2/assets/images/block-analitica.png",
     "name": "Block Analitica",
+    "url": "https://blockanalitica.com/",
     "verified": true,
     "addresses": {
       "1": [
         "0x2a933dbd0D9e32593e62702028Edcab437CE3cBA",
         "0x2566f66f68ed438726AD904524FB306A03FdB80B"
       ],
-      "8453": [
-        "0x4b8f6CADb8A2B222e8840E8aDDc32E031794A4D6"
-      ]
+      "8453": ["0x4b8f6CADb8A2B222e8840E8aDDc32E031794A4D6"]
     },
     "id": "block-analitica",
     "socials": {
@@ -93,6 +94,7 @@
   },
   {
     "image": "https://cdn.morpho.org/v2/assets/images/bprotocol.png",
+    "url": "https://www.bprotocol.org/",
     "name": "B.Protocol",
     "verified": true,
     "addresses": {
@@ -114,17 +116,12 @@
   {
     "image": "https://cdn.morpho.org/v2/assets/images/re7.png",
     "name": "RE7 Labs",
+    "url": "https://www.re7labs.xyz/",
     "verified": true,
     "addresses": {
-      "1": [
-        "0xE86399fE6d7007FdEcb08A2ee1434Ee677a04433"
-      ],
-      "137": [
-        "0xD8B0F4e54a8dac04E0A57392f5A630cEdb99C940"
-      ],
-      "8453": [
-        "0xD8B0F4e54a8dac04E0A57392f5A630cEdb99C940"
-      ]
+      "1": ["0xE86399fE6d7007FdEcb08A2ee1434Ee677a04433"],
+      "137": ["0xD8B0F4e54a8dac04E0A57392f5A630cEdb99C940"],
+      "8453": ["0xD8B0F4e54a8dac04E0A57392f5A630cEdb99C940"]
     },
     "id": "re7-labs",
     "socials": {
@@ -134,11 +131,10 @@
   {
     "image": "https://cdn.morpho.org/v2/assets/images/fence.svg",
     "name": "Fence",
+    "url": "https://www.fence.finance/",
     "verified": true,
     "addresses": {
-      "1": [
-        "0xF92971B4D9e6257CF562400ed81d2986F28a8c26"
-      ]
+      "1": ["0xF92971B4D9e6257CF562400ed81d2986F28a8c26"]
     },
     "id": "fence",
     "socials": {
@@ -148,6 +144,7 @@
   {
     "image": "https://cdn.morpho.org/v2/assets/images/steakhouse.svg",
     "name": "Steakhouse Financial",
+    "url": "https://www.steakhouse.financial",
     "verified": true,
     "addresses": {
       "1": [
@@ -170,14 +167,11 @@
   {
     "image": "https://cdn.morpho.org/v2/assets/images/relend.png",
     "name": "Relend Network",
+    "url": "https://relend.network/",
     "verified": true,
     "addresses": {
-      "1": [
-        "0xD6D14E60c0DAFcB3B77B296fe718623Ec84e5eb3"
-      ],
-      "8453": [
-        "0x32f75c3ee6aD872Eb3138020885E94E2842b8433"
-      ]
+      "1": ["0xD6D14E60c0DAFcB3B77B296fe718623Ec84e5eb3"],
+      "8453": ["0x32f75c3ee6aD872Eb3138020885E94E2842b8433"]
     },
     "id": "relend-network",
     "socials": {
@@ -187,11 +181,10 @@
   {
     "image": "https://cdn.morpho.org/v2/assets/images/hyperithm.svg",
     "name": "Hyperithm",
+    "url": "https://www.hyperithm.com/",
     "verified": true,
     "addresses": {
-      "1": [
-        "0x16fa314141C76D4a0675f5e8e3CCBE4E0fA22C7c"
-      ]
+      "1": ["0x16fa314141C76D4a0675f5e8e3CCBE4E0fA22C7c"]
     },
     "id": "hyperithm",
     "socials": {
@@ -201,14 +194,11 @@
   {
     "image": "https://cdn.morpho.org/v2/assets/images/spark.svg",
     "name": "SparkDAO",
+    "url": "https://spark.fi/",
     "verified": true,
     "addresses": {
-      "1": [
-        "0x3300f198988e4C9C63F75dF86De36421f06af8c4"
-      ],
-      "8453": [
-        "0xF93B7122450A50AF3e5A76E1d546e95Ac1d0F579"
-      ]
+      "1": ["0x3300f198988e4C9C63F75dF86De36421f06af8c4"],
+      "8453": ["0xF93B7122450A50AF3e5A76E1d546e95Ac1d0F579"]
     },
     "id": "sparkdao",
     "socials": {
@@ -218,11 +208,10 @@
   {
     "image": "https://cdn.morpho.org/v2/assets/images/llamarisk.svg",
     "name": "LlamaRisk",
+    "url": "https://www.llamarisk.com/",
     "verified": true,
     "addresses": {
-      "1": [
-        "0x7e246fAce452AC43F5dC60c41EE14C88c37951c6"
-      ]
+      "1": ["0x7e246fAce452AC43F5dC60c41EE14C88c37951c6"]
     },
     "id": "llamarisk",
     "socials": {
@@ -232,15 +221,14 @@
   {
     "image": "https://cdn.morpho.org/v2/assets/images/apostro.svg",
     "name": "Apostro",
+    "url": "https://apostro.xyz",
     "verified": true,
     "addresses": {
       "1": [
         "0xf726311F85D45a7fECfFbC94bD8508a0A39958c6",
         "0xC91578e51BCE35844E345CC7F733b4bBf6721734"
       ],
-      "8453": [
-        "0xf726311F85D45a7fECfFbC94bD8508a0A39958c6"
-      ]
+      "8453": ["0xf726311F85D45a7fECfFbC94bD8508a0A39958c6"]
     },
     "id": "apostro",
     "socials": {
@@ -250,6 +238,7 @@
   {
     "image": "https://cdn.morpho.org/v2/assets/images/leadblock.png",
     "name": "LeadBlock",
+    "url": "https://leadblockpartners.com/",
     "verified": true,
     "addresses": {
       "1": [
@@ -265,6 +254,7 @@
   {
     "image": "https://cdn.morpho.org/v2/assets/images/alphaping.png",
     "name": "Alphaping",
+    "url": "https://alphaping.ch/",
     "verified": true,
     "addresses": {
       "1": [
@@ -281,6 +271,7 @@
   {
     "image": "https://cdn.morpho.org/v2/assets/images/hakutora.png",
     "name": "Hakutora",
+    "url": "https://hakutora.xyz/",
     "verified": true,
     "addresses": {
       "1": [
@@ -296,6 +287,7 @@
   {
     "image": "https://cdn.morpho.org/v2/assets/images/ouroboros.svg",
     "name": "Ouroboros Capital",
+    "url": "https://ourocap.io/",
     "verified": true,
     "addresses": {
       "1": [
@@ -311,6 +303,7 @@
   {
     "image": "https://cdn.morpho.org/v2/assets/images/clearstar.png",
     "name": "Clearstar",
+    "url": "https://www.linkedin.com/company/clearstar-labs-ag/",
     "verified": true,
     "addresses": {
       "8453": [
@@ -326,6 +319,7 @@
   {
     "image": "https://cdn.morpho.org/v2/assets/images/m11c.png",
     "name": "M11C",
+    "url": "https://www.m11credit.com/",
     "verified": true,
     "addresses": {
       "1": [
@@ -341,14 +335,11 @@
   {
     "image": "https://cdn.morpho.org/v2/assets/images/yearn.png",
     "name": "Yearn",
+    "url": "https://yearn.fi/apps",
     "verified": true,
     "addresses": {
-      "1": [
-        "0xe5e2Baf96198c56380dDD5E992D7d1ADa0e989c0"
-      ],
-      "8453": [
-        "0xFEaE2F855250c36A77b8C68dB07C4dD9711fE36F"
-      ]
+      "1": ["0xe5e2Baf96198c56380dDD5E992D7d1ADa0e989c0"],
+      "8453": ["0xFEaE2F855250c36A77b8C68dB07C4dD9711fE36F"]
     },
     "id": "yearn",
     "socials": {
@@ -365,43 +356,33 @@
       ]
     },
     "ownerOnly": true,
-    "id": "swissborg",
-    "socials": {}
+    "id": "swissborg"
   },
   {
     "name": "Seamless",
     "verified": true,
     "addresses": {
-      "8453": [
-        "0x639d2dD24304aC2e6A691d8c1cFf4a2665925fee"
-      ]
+      "8453": ["0x639d2dD24304aC2e6A691d8c1cFf4a2665925fee"]
     },
     "ownerOnly": true,
-    "id": "seamless",
-    "socials": {}
+    "id": "seamless"
   },
   {
     "name": "Moonwell",
     "verified": true,
     "addresses": {
-      "8453": [
-        "0x8b621804a7637b781e2BbD58e256a591F2dF7d51"
-      ]
+      "8453": ["0x8b621804a7637b781e2BbD58e256a591F2dF7d51"]
     },
     "ownerOnly": true,
-    "id": "moonwell",
-    "socials": {}
+    "id": "moonwell"
   },
   {
     "name": "Compound DAO",
     "verified": true,
     "addresses": {
-      "137": [
-        "0xCC3E7c85Bb0EE4f09380e041fee95a0caeDD4a02"
-      ]
+      "137": ["0xCC3E7c85Bb0EE4f09380e041fee95a0caeDD4a02"]
     },
     "ownerOnly": true,
-    "id": "compound-dao",
-    "socials": {}
+    "id": "compound-dao"
   }
 ]

--- a/data/curators-whitelist.json
+++ b/data/curators-whitelist.json
@@ -2,7 +2,6 @@
   {
     "image": "https://cdn.morpho.org/v2/assets/images/mevcapital.png",
     "name": "MEV Capital",
-    "url": "https://mevcapital.com/",
     "verified": true,
     "addresses": {
       "1": [
@@ -10,29 +9,37 @@
         "0x06590Fef209Ebc1f8eEF83dA05984cD4eFf0d0E3",
         "0x6fA5d361Ab8165347F636217001E22a7cEF09B48"
       ]
+    },
+    "id": "mev-capital",
+    "socials": {
+      "url": "https://mevcapital.com/"
     }
   },
   {
     "image": "https://cdn.morpho.org/v2/assets/images/gauntlet.svg",
     "name": "Gauntlet",
-    "url": "https://www.gauntlet.xyz/",
     "verified": true,
     "addresses": {
       "1": [
         "0x9E33faAE38ff641094fa68c65c2cE600b3410585",
         "0xC684c6587712e5E7BDf9fD64415F23Bd2b05fAec"
       ],
+      "137": [
+        "0x9E33faAE38ff641094fa68c65c2cE600b3410585"
+      ],
       "8453": [
         "0x9E33faAE38ff641094fa68c65c2cE600b3410585",
         "0x5a4E19842e09000a582c20A4f524C26Fb48Dd4D0"
-      ],
-      "137": ["0x9E33faAE38ff641094fa68c65c2cE600b3410585"]
+      ]
+    },
+    "id": "gauntlet",
+    "socials": {
+      "url": "https://www.gauntlet.xyz/"
     }
   },
   {
     "image": "https://cdn.morpho.org/v2/assets/images/9summits.png",
     "name": "9Summits",
-    "url": "https://9summits.io/",
     "verified": true,
     "addresses": {
       "1": [
@@ -45,36 +52,47 @@
         "0x59e608E4842162480591032f3c8b0aE55C98d104",
         "0x23E6aecB76675462Ad8f2B31eC7C492060c2fAEF"
       ]
+    },
+    "id": "9summits",
+    "socials": {
+      "url": "https://9summits.io/"
     }
   },
   {
     "image": "https://cdn.morpho.org/v2/assets/images/tulipa-capital.svg",
     "name": "Tulipa Capital",
-    "url": "https://www.tulipa.capital/",
     "verified": true,
     "addresses": {
       "1": [
         "0xB65b8CF358A2A4C62e1153eC88fc0eD43fB73bC4",
         "0x30a38f1a27036aE7b1a3679646739Fb913B9B244"
       ]
+    },
+    "id": "tulipa-capital",
+    "socials": {
+      "url": "https://www.tulipa.capital/"
     }
   },
   {
     "image": "https://cdn.morpho.org/v2/assets/images/block-analitica.png",
     "name": "Block Analitica",
-    "url": "https://blockanalitica.com/",
     "verified": true,
     "addresses": {
       "1": [
         "0x2a933dbd0D9e32593e62702028Edcab437CE3cBA",
         "0x2566f66f68ed438726AD904524FB306A03FdB80B"
       ],
-      "8453": ["0x4b8f6CADb8A2B222e8840E8aDDc32E031794A4D6"]
+      "8453": [
+        "0x4b8f6CADb8A2B222e8840E8aDDc32E031794A4D6"
+      ]
+    },
+    "id": "block-analitica",
+    "socials": {
+      "url": "https://blockanalitica.com/"
     }
   },
   {
     "image": "https://cdn.morpho.org/v2/assets/images/bprotocol.png",
-    "url": "https://www.bprotocol.org/",
     "name": "B.Protocol",
     "verified": true,
     "addresses": {
@@ -87,30 +105,49 @@
         "0x4b8f6CADb8A2B222e8840E8aDDc32E031794A4D6",
         "0x32f75c3ee6aD872Eb3138020885E94E2842b8433"
       ]
+    },
+    "id": "b-protocol",
+    "socials": {
+      "url": "https://www.bprotocol.org/"
     }
   },
   {
     "image": "https://cdn.morpho.org/v2/assets/images/re7.png",
     "name": "RE7 Labs",
-    "url": "https://www.re7labs.xyz/",
     "verified": true,
     "addresses": {
-      "1": ["0xE86399fE6d7007FdEcb08A2ee1434Ee677a04433"],
-      "8453": ["0xD8B0F4e54a8dac04E0A57392f5A630cEdb99C940"],
-      "137": ["0xD8B0F4e54a8dac04E0A57392f5A630cEdb99C940"]
+      "1": [
+        "0xE86399fE6d7007FdEcb08A2ee1434Ee677a04433"
+      ],
+      "137": [
+        "0xD8B0F4e54a8dac04E0A57392f5A630cEdb99C940"
+      ],
+      "8453": [
+        "0xD8B0F4e54a8dac04E0A57392f5A630cEdb99C940"
+      ]
+    },
+    "id": "re7-labs",
+    "socials": {
+      "url": "https://www.re7labs.xyz/"
     }
   },
   {
     "image": "https://cdn.morpho.org/v2/assets/images/fence.svg",
     "name": "Fence",
-    "url": "https://www.fence.finance/",
     "verified": true,
-    "addresses": { "1": ["0xF92971B4D9e6257CF562400ed81d2986F28a8c26"] }
+    "addresses": {
+      "1": [
+        "0xF92971B4D9e6257CF562400ed81d2986F28a8c26"
+      ]
+    },
+    "id": "fence",
+    "socials": {
+      "url": "https://www.fence.finance/"
+    }
   },
   {
     "image": "https://cdn.morpho.org/v2/assets/images/steakhouse.svg",
     "name": "Steakhouse Financial",
-    "url": "https://www.steakhouse.financial",
     "verified": true,
     "addresses": {
       "1": [
@@ -124,73 +161,110 @@
         "0x0000aeB716a0DF7A9A1AAd119b772644Bc089dA8",
         "0x827e86072B06674a077f592A531dcE4590aDeCdB"
       ]
+    },
+    "id": "steakhouse-financial",
+    "socials": {
+      "url": "https://www.steakhouse.financial"
     }
   },
   {
     "image": "https://cdn.morpho.org/v2/assets/images/relend.png",
     "name": "Relend Network",
-    "url": "https://relend.network/",
     "verified": true,
     "addresses": {
-      "1": ["0xD6D14E60c0DAFcB3B77B296fe718623Ec84e5eb3"],
-      "8453": ["0x32f75c3ee6aD872Eb3138020885E94E2842b8433"]
+      "1": [
+        "0xD6D14E60c0DAFcB3B77B296fe718623Ec84e5eb3"
+      ],
+      "8453": [
+        "0x32f75c3ee6aD872Eb3138020885E94E2842b8433"
+      ]
+    },
+    "id": "relend-network",
+    "socials": {
+      "url": "https://relend.network/"
     }
   },
   {
     "image": "https://cdn.morpho.org/v2/assets/images/hyperithm.svg",
     "name": "Hyperithm",
-    "url": "https://www.hyperithm.com/",
     "verified": true,
     "addresses": {
-      "1": ["0x16fa314141C76D4a0675f5e8e3CCBE4E0fA22C7c"]
+      "1": [
+        "0x16fa314141C76D4a0675f5e8e3CCBE4E0fA22C7c"
+      ]
+    },
+    "id": "hyperithm",
+    "socials": {
+      "url": "https://www.hyperithm.com/"
     }
   },
   {
     "image": "https://cdn.morpho.org/v2/assets/images/spark.svg",
     "name": "SparkDAO",
-    "url": "https://spark.fi/",
     "verified": true,
     "addresses": {
-      "1": ["0x3300f198988e4C9C63F75dF86De36421f06af8c4"],
-      "8453": ["0xF93B7122450A50AF3e5A76E1d546e95Ac1d0F579"]
+      "1": [
+        "0x3300f198988e4C9C63F75dF86De36421f06af8c4"
+      ],
+      "8453": [
+        "0xF93B7122450A50AF3e5A76E1d546e95Ac1d0F579"
+      ]
+    },
+    "id": "sparkdao",
+    "socials": {
+      "url": "https://spark.fi/"
     }
   },
   {
     "image": "https://cdn.morpho.org/v2/assets/images/llamarisk.svg",
     "name": "LlamaRisk",
-    "url": "https://www.llamarisk.com/",
     "verified": true,
-    "addresses": { "1": ["0x7e246fAce452AC43F5dC60c41EE14C88c37951c6"] }
+    "addresses": {
+      "1": [
+        "0x7e246fAce452AC43F5dC60c41EE14C88c37951c6"
+      ]
+    },
+    "id": "llamarisk",
+    "socials": {
+      "url": "https://www.llamarisk.com/"
+    }
   },
   {
     "image": "https://cdn.morpho.org/v2/assets/images/apostro.svg",
     "name": "Apostro",
-    "url": "https://apostro.xyz",
     "verified": true,
     "addresses": {
       "1": [
         "0xf726311F85D45a7fECfFbC94bD8508a0A39958c6",
         "0xC91578e51BCE35844E345CC7F733b4bBf6721734"
       ],
-      "8453": ["0xf726311F85D45a7fECfFbC94bD8508a0A39958c6"]
+      "8453": [
+        "0xf726311F85D45a7fECfFbC94bD8508a0A39958c6"
+      ]
+    },
+    "id": "apostro",
+    "socials": {
+      "url": "https://apostro.xyz"
     }
   },
   {
     "image": "https://cdn.morpho.org/v2/assets/images/leadblock.png",
     "name": "LeadBlock",
-    "url": "https://leadblockpartners.com/",
     "verified": true,
     "addresses": {
       "1": [
         "0x825214AFa86f1F192F2FbA98FCB530EAdb473a5D",
         "0x54f90Cbed0ba50fE7eE6113d8651eBdbF35938e2"
       ]
+    },
+    "id": "leadblock",
+    "socials": {
+      "url": "https://leadblockpartners.com/"
     }
   },
   {
     "image": "https://cdn.morpho.org/v2/assets/images/alphaping.png",
     "name": "Alphaping",
-    "url": "https://alphaping.ch/",
     "verified": true,
     "addresses": {
       "1": [
@@ -198,64 +272,87 @@
         "0x6788c8ad65E85CCa7224a0B46D061EF7D81F9Da5",
         "0xD50B9Bbf136D1BD5CD5AC6ed9b3F26c458a6d4A6"
       ]
+    },
+    "id": "alphaping",
+    "socials": {
+      "url": "https://alphaping.ch/"
     }
   },
   {
     "image": "https://cdn.morpho.org/v2/assets/images/hakutora.png",
     "name": "Hakutora",
-    "url": "https://hakutora.xyz/",
     "verified": true,
     "addresses": {
       "1": [
         "0x2413A57FBD695f6B13C1D8d7D30EE10fa61b1b02",
         "0x345023d92f3051bB2B68DF79dFf760EccFEE80ED"
       ]
+    },
+    "id": "hakutora",
+    "socials": {
+      "url": "https://hakutora.xyz/"
     }
   },
   {
     "image": "https://cdn.morpho.org/v2/assets/images/ouroboros.svg",
     "name": "Ouroboros Capital",
-    "url": "https://ourocap.io/",
     "verified": true,
     "addresses": {
       "1": [
         "0x4c5D2A0240b889f49E6a9E893d089933BD2802cd",
         "0x7C5805ff6F70265bCc4FC44BE6a9DB225A506bc8"
       ]
+    },
+    "id": "ouroboros-capital",
+    "socials": {
+      "url": "https://ourocap.io/"
     }
   },
   {
     "image": "https://cdn.morpho.org/v2/assets/images/clearstar.png",
     "name": "Clearstar",
-    "url": "https://www.linkedin.com/company/clearstar-labs-ag/",
     "verified": true,
     "addresses": {
       "8453": [
         "0x30988479C2E6a03E7fB65138b94762D41a733458",
         "0x72882eb5D27C7088DFA6DDE941DD42e5d184F0ef"
       ]
+    },
+    "id": "clearstar",
+    "socials": {
+      "url": "https://www.linkedin.com/company/clearstar-labs-ag/"
     }
   },
   {
     "image": "https://cdn.morpho.org/v2/assets/images/m11c.png",
     "name": "M11C",
-    "url": "https://www.m11credit.com/",
     "verified": true,
     "addresses": {
       "1": [
         "0x274F294670b67a5ACd4cfEa280F75B842e6e9B99",
         "0xc9E1C0E63ff44D8b4061E44374419a072B831F4e"
       ]
+    },
+    "id": "m11c",
+    "socials": {
+      "url": "https://www.m11credit.com/"
     }
   },
   {
     "image": "https://cdn.morpho.org/v2/assets/images/yearn.png",
     "name": "Yearn",
-    "url": "https://yearn.fi/apps",
     "verified": true,
     "addresses": {
-      "1": ["0xe5e2Baf96198c56380dDD5E992D7d1ADa0e989c0"],
-      "8453": ["0xFEaE2F855250c36A77b8C68dB07C4dD9711fE36F"]
+      "1": [
+        "0xe5e2Baf96198c56380dDD5E992D7d1ADa0e989c0"
+      ],
+      "8453": [
+        "0xFEaE2F855250c36A77b8C68dB07C4dD9711fE36F"
+      ]
+    },
+    "id": "yearn",
+    "socials": {
+      "url": "https://yearn.fi/apps"
     }
   },
   {
@@ -267,30 +364,44 @@
         "0xAC15982Ca8A8e8BAc738FE492b84D8761B4384a3"
       ]
     },
-    "ownerOnly": true
+    "ownerOnly": true,
+    "id": "swissborg",
+    "socials": {}
   },
   {
     "name": "Seamless",
     "verified": true,
     "addresses": {
-      "8453": ["0x639d2dD24304aC2e6A691d8c1cFf4a2665925fee"]
+      "8453": [
+        "0x639d2dD24304aC2e6A691d8c1cFf4a2665925fee"
+      ]
     },
-    "ownerOnly": true
+    "ownerOnly": true,
+    "id": "seamless",
+    "socials": {}
   },
   {
     "name": "Moonwell",
     "verified": true,
     "addresses": {
-      "8453": ["0x8b621804a7637b781e2BbD58e256a591F2dF7d51"]
+      "8453": [
+        "0x8b621804a7637b781e2BbD58e256a591F2dF7d51"
+      ]
     },
-    "ownerOnly": true
+    "ownerOnly": true,
+    "id": "moonwell",
+    "socials": {}
   },
   {
     "name": "Compound DAO",
     "verified": true,
     "addresses": {
-      "137": ["0xCC3E7c85Bb0EE4f09380e041fee95a0caeDD4a02"]
+      "137": [
+        "0xCC3E7c85Bb0EE4f09380e041fee95a0caeDD4a02"
+      ]
     },
-    "ownerOnly": true
+    "ownerOnly": true,
+    "id": "compound-dao",
+    "socials": {}
   }
 ]

--- a/test/json/validation/curators.test.ts
+++ b/test/json/validation/curators.test.ts
@@ -16,7 +16,7 @@ interface Curator {
   verified: boolean;
   addresses: CuratorAddresses;
   ownerOnly?: boolean;
-  socials: Record<string, string>;
+  socials?: Record<string, string>;
 }
 
 interface ChainalysisResponse {
@@ -68,12 +68,14 @@ describe("curators-whitelist.json validation", () => {
     const baseUrl = "https://cdn.morpho.org/v2/assets/images";
 
     curators.forEach((curator) => {
-      if (!curator.image || curator.image === "") {
-        errors.push(`Empty image URL for curator: ${curator.name}`);
-      } else if (!curator.image.startsWith(baseUrl)) {
-        errors.push(
-          `Invalid image URL for curator ${curator.name}: ${curator.image}. Must start with ${baseUrl}`
-        );
+      if (!curator.ownerOnly) {
+        if (!curator.image) {
+          errors.push(`Empty image URL for curator: ${curator.name}`);
+        } else if (!curator.image.startsWith(baseUrl)) {
+          errors.push(
+            `Invalid image URL for curator ${curator.name}: ${curator.image}. Must start with ${baseUrl}`
+          );
+        }
       }
     });
 
@@ -86,11 +88,11 @@ describe("curators-whitelist.json validation", () => {
     const errors: string[] = [];
 
     curators.forEach((curator) => {
-      if (!curator.socials.url) {
+      if (!curator.ownerOnly && !curator.socials?.url) {
         errors.push(`Missing url for curator: ${curator.name}`);
       }
 
-      const invalidSocials = Object.keys(curator.socials).filter(
+      const invalidSocials = Object.keys(curator.socials ?? {}).filter(
         (k) => !SOCIALS_TYPES.includes(k)
       );
 


### PR DESCRIPTION
To prepare for the curator pages, we need the following:
- a unique id for each curator 
  - Since this id is gonna be used in the curator's page url:
    - it shouldn't change (or it's gonna break the existing urls)
    - it should be url compatible (only lower letters, numbers, and dashes)
  - I initiated it using the curator's name, but it can be changed if they request it
- I moved the `url` in a `socials` mapping, which will allow us to extend it with other socials links (twitter, discord, ...)
- I don't know why this was initially a requirement, but the `onlyOwner` conditions to not have `url` and `image` has been removed for better flexibility (it has been required by Hayden)