### PR TITLE
feat(vault): add PT vault

### DIFF
--- a/data/vaults-whitelist.json
+++ b/data/vaults-whitelist.json
@@ -3630,5 +3630,26 @@
         "timestamp": 1746795600
       }
     ]
+  },
+  {
+    "address": "0xd41830d88dfD08678b0B886E0122193d54b02Acc",
+    "chainId": 1,
+    "image": "https://cdn.morpho.org/v2/assets/images/mevcapital.png",
+    "description": "The MEV Capital PTs USDC vault provides a set of PTs collateral markets with an optimized risk-adjusted return through an active rebalancing strategy.",
+    "forumLink": "https://forum.morpho.org/c/metamorpho/mev-capital/30",
+    "curators": [
+      {
+        "name": "MEV Capital",
+        "image": "https://cdn.morpho.org/v2/assets/images/mevcapital.png",
+        "url": "https://mevcapital.com/",
+        "verified": true
+      }
+    ],
+    "history": [
+      {
+        "action": "added",
+        "timestamp": 1748347096
+      }
+    ]
   }
 ]


### PR DESCRIPTION
**FIXES INTEG-2432**
Whitelisting vault [MEV Capital PTs USDC](https://app.morpho.org/ethereum/vault/0xd41830d88dfD08678b0B886E0122193d54b02Acc/mev-capital-pts-usdc?subTab=risk)

Careful!
Timelock displayed on the app is 0D but this is a display issue being fixed.
Timelock at contract level is 3D: https://etherscan.io/address/0xd41830d88dfd08678b0b886e0122193d54b02acc#readContract#F38