### PR TITLE
feat(clearstar): add bold markets and vault

### DIFF
--- a/data/price-feeds.json
+++ b/data/price-feeds.json
@@ -7578,5 +7578,13 @@
     "description": "PT-iUSD-4SEP2025/iUSD PendleChainlinkOracle",
     "pair": ["PT-iUSD-4SEP2025", "iUSD"],
     "decimals": 18
+  },
+  {
+    "chainId": 1,
+    "address": "0x596cDF5D33486b035e8482688c638E7dcAf25a7b",
+    "vendor": "Pyth Network",
+    "description": "BOLD/USD Pyth Network feed",
+    "pair": ["BOLD", "USD"],
+    "decimals": 8
   }
 ]

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -3554,5 +3554,27 @@
       "alternativeHardcodedOracles": ["USDC"]
     },
     "isWhitelisted": true
+  },
+  {
+    "chainId": 1,
+    "address": "0x50Bd66D59911F5e086Ec87aE43C811e0D059DD11",
+    "name": "sBold",
+    "symbol": "sBOLD",
+    "decimals": 18,
+    "metadata": {
+      "logoURI": "https://cdn.morpho.org/assets/logos/bold.svg"
+    },
+    "isWhitelisted": true
+  },
+  {
+    "chainId": 1,
+    "address": "0x6440f144b7e50D6a8439336510312d2F54beB01D",
+    "name": "BOLD Stablecoin",
+    "symbol": "BOLD",
+    "decimals": 18,
+    "metadata": {
+      "logoURI": "https://cdn.morpho.org/assets/logos/bold.svg"
+    },
+    "isWhitelisted": true
   }
 ]

--- a/data/vaults-whitelist.json
+++ b/data/vaults-whitelist.json
@@ -4176,5 +4176,26 @@
         "timestamp": 1750423278
       }
     ]
+  },
+  {
+    "address": "0xfBC84DBfAA2196853FdB6cAE52ef8F56DD76770a",
+    "chainId": 1,
+    "image": "https://cdn.morpho.org/v2/assets/images/clearstar.svg",
+    "description": "The BOLD Reactor optimizes liquidity and yield within the Liquity ecosystem.",
+    "forumLink": "https://forum.morpho.org/c/vaults/clearstar-labs/40",
+    "curators": [
+      {
+        "name": "Clearstar",
+        "image": "https://cdn.morpho.org/v2/assets/images/clearstar.svg",
+        "url": "https://www.linkedin.com/company/clearstar-labs-ag/",
+        "verified": true
+      }
+    ],
+    "history": [
+      {
+        "action": "added",
+        "timestamp": 1750851563
+      }
+    ]
   }
 ]


### PR DESCRIPTION
**FIXES INTEG-2678**
[BOLD Reactor vault](https://app.morpho.org/ethereum/vault/0xfBC84DBfAA2196853FdB6cAE52ef8F56DD76770a/bold-reactor?subTab=risk)
seeded ✅
3D timelock ✅
curator/owner addresses whitelisted ✅
BOLD token added ✅

**FIXES INTEG-2680**
[cbETH/BOLD
](https://app.morpho.org/ethereum/market/0x3875de955cfd8f8328a5df0ca04654ace58dfe94a49352645044e850daa41c18/cbeth-bold) oracle decoder ✅

**FIXES INTEG-2681**
[WBTC/BOLD](https://app.morpho.org/ethereum/market/0xeb9e8da9606c3762f1128964b6dc30edc6dde10e78b2e6402b28d30974f2bae2/wbtc-bold)
oracle decoder ✅

**FIXES INTEG-2682**
[cbBTC/BOLD](https://app.morpho.org/ethereum/market/0x344d7122e517ec0bc93c16262b39eb42c4da31e2ea736751fe65e572deebd8c3/cbbtc-bold)
oracle decoder ✅

For the 3 above, BOLD/USD Pyth feed added

sBOLD will be used in a market soon to be created