### PR TITLE
feat(market): lbtc-vbwbtc

### DIFF
--- a/data/price-feeds.json
+++ b/data/price-feeds.json
@@ -7842,5 +7842,13 @@
     "description": "USDC/USD feed",
     "pair": ["USDC", "USD"],
     "decimals": 18
+  },
+  {
+    "chainId": 747474,
+    "address": "0xb9D0073aCb296719C26a8BF156e4b599174fe1d5",
+    "vendor": "Redstone",
+    "description": "RedStone Price Feed for LBTC_FUNDAMENTAL",
+    "pair": ["LBTC", "BTC"],
+    "decimals": 8
   }
 ]


### PR DESCRIPTION
clears [LBTC/vbWBTC](https://app.morpho.org/katana/market/0x60b54e17d55b765955a20908ed5143192a48df7fd3833f7f7fe86504bf6c4c1a/lbtc-vbwbtc)
feed ✅ ([redstone link](https://app.redstone.finance/app/feeds/katana/lbtc_fundamental/))
oracle decoder ✅
<img width="1661" alt="Screenshot 2025-07-04 at 15 23 36" src="https://github.com/user-attachments/assets/8b4867e6-0a83-49ad-95d0-1afa8d4e7750" />


no related issue (issue 2744 has several markets in it - stuck by oracle contracts not verified)