### PR TITLE
Feat/vault and markets w29

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -3591,6 +3591,39 @@
   },
   {
     "chainId": 747474,
+    "address": "0x3ba1fbC4c3aEA775d335b31fb53778f46FD3a330",
+    "name": "Katana Network Token (wrapped)",
+    "symbol": "KAT",
+    "decimals": 18,
+    "metadata": {
+      "logoURI": "https://cdn.morpho.org/assets/logos/kat.svg"
+    },
+    "isWhitelisted": true
+  },
+  {
+    "chainId": 747474,
+    "address": "0x6E9C1F88a960fE63387eb4b71BC525a9313d8461",
+    "name": "Katana Network Token (wrapped v2)",
+    "symbol": "KAT",
+    "decimals": 18,
+    "metadata": {
+      "logoURI": "https://cdn.morpho.org/assets/logos/kat.svg"
+    },
+    "isWhitelisted": true
+  },
+  {
+    "chainId": 747474,
+    "address": "0x17BFF452dae47e07CeA877Ff0E1aba17eB62b0aB",
+    "name": "SushiToken",
+    "symbol": "SUSHI",
+    "decimals": 18,
+    "metadata": {
+      "logoURI": "https://cdn.morpho.org/assets/logos/sushi.svg"
+    },
+    "isWhitelisted": true
+  },
+  {
+    "chainId": 747474,
     "address": "0xEE7D8BCFb72bC1880D0Cf19822eB0A2e6577aB62",
     "name": "Vault Bridge ETH",
     "symbol": "vbETH",

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -3838,5 +3838,16 @@
       "logoURI": "https://cdn.morpho.org/assets/logos/pt-cusdo.svg"
     },
     "isWhitelisted": true
+  },
+  {
+    "chainId": 1,
+    "address": "0xdde3eC717f220Fc6A29D6a4Be73F91DA5b718e55",
+    "name": "USDU",
+    "symbol": "USDU",
+    "decimals": 18,
+    "metadata": {
+      "logoURI": "https://cdn.morpho.org/assets/logos/usdu.svg"
+    },
+    "isWhitelisted": true
   }
 ]

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -3702,9 +3702,9 @@
   },
   {
     "chainId": 1,
-    "address": "0x7bAFb26A485bf7bB4B0D0b02996c79C5Af6493bc",
+    "address": "0x7bAFb26A485bf7bB4B0D0b02996c79C5Af6493bc",  
     "name": "Wrapped LP Ethena sUSDE 31JUL2025",
-    "symbol": "LP-sUSDE-31JUL2025",
+    "symbol": "Wrapped-LP-sUSDE-31JUL2025",
     "decimals": 18,
     "metadata": {
       "logoURI": "https://cdn.morpho.org/assets/logos/lp-susde.svg"
@@ -3715,7 +3715,7 @@
     "chainId": 1,
     "address": "0x10cbdAe955725baC7bCc20335e304b4A48fD8919",
     "name": "Wrapped LP Ethereal eUSDE 14AUG2025",
-    "symbol": "LP-eUSDE-14AUG2025",
+    "symbol": "Wrapped-LP-eUSDE-14AUG2025",
     "decimals": 18,
     "metadata": {
       "logoURI": "https://cdn.morpho.org/assets/logos/lp-eusde.svg"
@@ -3726,7 +3726,7 @@
     "chainId": 1,
     "address": "0xaB025d7b57B0902A2797599F3eB07477400e62B0",
     "name": "Wrapped LP Ethena sUSDE 25SEP2025",
-    "symbol": "LP-sUSDE-25SEP2025",
+    "symbol": "Wrapped-LP-sUSDE-25SEP2025",
     "decimals": 18,
     "metadata": {
       "logoURI": "https://cdn.morpho.org/assets/logos/lp-susde.svg"
@@ -3841,12 +3841,12 @@
   },
   {
     "chainId": 1,
-    "address": "0xdde3eC717f220Fc6A29D6a4Be73F91DA5b718e55",
-    "name": "USDU",
-    "symbol": "USDU",
+    "address": "0x8ddac7aa85Ce324AF75a3bFcB876375555d43BB8",
+    "name": "Wrapped LP USDS Stablecoin 14AUG2025",
+    "symbol": "Wrapped-LP-USDS-14AUG2025",
     "decimals": 18,
     "metadata": {
-      "logoURI": "https://cdn.morpho.org/assets/logos/usdu.svg"
+      "logoURI": "https://cdn.morpho.org/assets/logos/lp-usds.svg"
     },
     "isWhitelisted": true
   }

--- a/data/vaults-whitelist.json
+++ b/data/vaults-whitelist.json
@@ -4512,5 +4512,26 @@
         "timestamp": 1751613695
       }
     ]
+  },
+  {
+    "address": "0xe107cCdeb8e20E499545C813f98Cc90619b29859",
+    "chainId": 747474,
+    "image": "https://cdn.morpho.org/v2/assets/images/yearn.svg",
+    "description": "Yearn OG vaults lend underlying assets to markets labeled as moderate risk (-2) by the Yearn team. Optimization across markets is handled automatically via an algorithm developed by Yearn. Supply caps are set based on various factors and continuously monitored by the Yearn team as well.",
+    "forumLink": "https://forum.morpho.org/c/vaults/yearn/42",
+    "curators": [
+      {
+        "name": "Yearn",
+        "image": "https://cdn.morpho.org/v2/assets/images/yearn.svg",
+        "url": "https://yearn.fi/apps",
+        "verified": true
+      }
+    ],
+    "history": [
+      {
+        "action": "added",
+        "timestamp": 1752216807
+      }
+    ]
   }
 ]


### PR DESCRIPTION
**FIXES INTEG-2849**
[Wrapped-LP-USDS-14AUG2025/USDT](https://app.morpho.org/ethereum/market/0x9a33209eee9e93f5f7aed04085f9f5e0ce9a7a103c476f5c30a0e5ca03c3d540/pendle-lpt-wrapped-usdt)
token ✅
oracle decoder ✅
<img width="1668" height="543" alt="Screenshot 2025-07-11 at 14 09 59" src="https://github.com/user-attachments/assets/a2d55e1b-1e71-4e64-99a1-9242f002c589" />


### Added "Wrapped" prefix to wrapped LP asset as there was confusion for user not able to use markets with their LP


**FIXES INTEG-2767**
[Yearn OG WBTC
](https://app.morpho.org/katana/vault/0xe107cCdeb8e20E499545C813f98Cc90619b29859/yearn-og-wbtc)
seed ✅
owner address wl ✅
timelock ✅


**FIXES INTEG-2850**
add 2 wrapped KAT token and Sushi token on Katana


