### PR TITLE
feat(address): add olympus owner only address

### DIFF
--- a/data/curators-whitelist.json
+++ b/data/curators-whitelist.json
@@ -547,5 +547,16 @@
     },
     "ownerOnly": true,
     "id": "elixir"
+  },
+  {
+    "name": "Olympus",
+    "image": "https://cdn.morpho.org/v2/assets/images/olympus.svg",
+    "url": "https://www.olympusdao.finance/",
+    "verified": true,
+    "addresses": {
+      "1": ["0x245cc372C84B3645Bf0Ffe6538620B04a217988B"]
+    },
+    "ownerOnly": true,
+    "id": "olympus"
   }
 ]


### PR DESCRIPTION
**FIXES INTEG-3024**

adding Olympus owner address to allow curator's display for **[Gauntlet Olympus sUSDS Vault](https://app.morpho.org/ethereum/vault/0x3365184e87d2Bd75961780454A5810BEc956F0dD/gauntlet-olympus-susds-vault?subTab=risk)**