### PR TITLE
fix(tokens): remove hyperevm tokens temporary

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -174,21 +174,7 @@
     },
     "isWhitelisted": true
   },
-  {
-    "name": "Resolv USD",
-    "address": "0x0aD339d66BF4AeD5ce31c64Bc37B3244b6394A77",
-    "symbol": "USR",
-    "decimals": 18,
-    "chainId": 999,
-    "metadata": {
-      "logoURI": "https://cdn.morpho.org/assets/logos/usr.svg",
-      "tags": [
-        "stablecoin",
-        "usd-pegged"
-      ]
-    },
-    "isWhitelisted": true
-  },
+
   {
     "name": "vbUSDC yVault",
     "address": "0x80c34BD3A3569E126e7055831036aa7b212cB159",
@@ -845,18 +831,6 @@
     "chainId": 1,
     "metadata": {
       "logoURI": "https://cdn.morpho.org/assets/logos/pt-rlp.svg",
-      "tags": []
-    },
-    "isWhitelisted": true
-  },
-  {
-    "name": "Unit Ethereum",
-    "address": "0xBe6727B535545C67d5cAa73dEa54865B92CF7907",
-    "symbol": "UETH",
-    "decimals": 18,
-    "chainId": 999,
-    "metadata": {
-      "logoURI": "https://cdn.morpho.org/assets/logos/ueth.svg",
       "tags": []
     },
     "isWhitelisted": true
@@ -3713,22 +3687,6 @@
     "isWhitelisted": true
   },
   {
-    "name": "USDeOFT",
-    "address": "0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34",
-    "symbol": "USDe",
-    "decimals": 18,
-    "chainId": 999,
-    "metadata": {
-      "logoURI": "https://cdn.morpho.org/assets/logos/usde.svg",
-      "tags": [
-        "stablecoin",
-        "usd-pegged",
-        "rwa"
-      ]
-    },
-    "isWhitelisted": true
-  },
-  {
     "chainId": 1,
     "address": "0x853d955aCEf822Db058eb8505911ED77F175b99e",
     "symbol": "FRAX",
@@ -4294,18 +4252,6 @@
     "isWhitelisted": true
   },
   {
-    "name": "Relend Network USDC",
-    "address": "0x9ab96A4668456896d45c301Bc3A15Cee76AA7B8D",
-    "symbol": "rUSDC",
-    "decimals": 6,
-    "chainId": 999,
-    "metadata": {
-      "logoURI": "https://cdn.morpho.org/assets/logos/rusdc.svg",
-      "tags": []
-    },
-    "isWhitelisted": true
-  },
-  {
     "chainId": 1,
     "address": "0xE87ed29896B91421ff43f69257ABF78300e40c7a",
     "name": "Re7 wstETH",
@@ -4422,18 +4368,7 @@
     },
     "isWhitelisted": true
   },
-  {
-    "name": "Wrapped HYPE",
-    "address": "0x5555555555555555555555555555555555555555",
-    "symbol": "WHYPE",
-    "decimals": 18,
-    "chainId": 999,
-    "metadata": {
-      "logoURI": "https://cdn.morpho.org/assets/logos/whype.svg",
-      "tags": []
-    },
-    "isWhitelisted": true
-  },
+
   {
     "chainId": 8453,
     "address": "0x83dB73EF5192de4B6a4c92bD0141Ba1a0Dc87c65",
@@ -4627,18 +4562,7 @@
     },
     "isWhitelisted": true
   },
-  {
-    "name": "USD₮0",
-    "address": "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb",
-    "symbol": "USD₮0",
-    "decimals": 6,
-    "chainId": 999,
-    "metadata": {
-      "logoURI": "https://cdn.morpho.org/assets/logos/usdt0.svg",
-      "tags": []
-    },
-    "isWhitelisted": true
-  },
+
   {
     "name": "vbWBTC yVault",
     "address": "0xAa0362eCC584B985056E47812931270b99C91f9d",


### PR DESCRIPTION
Api is not handling tokens with not defined support. I'll ensure better resilience api side but in the meantime, let's remove hyperevm assets until supported in the api