### PR TITLE
chore: remove 57 V1 vaults from listing

### DIFF
--- a/data/vaults-listing.json
+++ b/data/vaults-listing.json
@@ -8,6 +8,10 @@
       {
         "action": "added",
         "timestamp": 1704292895
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -32,6 +36,10 @@
       {
         "action": "added",
         "timestamp": 1747056007
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -116,6 +124,10 @@
       {
         "action": "added",
         "timestamp": 1745847527
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -172,6 +184,10 @@
       {
         "action": "added",
         "timestamp": 1736760937
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -224,6 +240,10 @@
       {
         "action": "added",
         "timestamp": 1727681425
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -252,6 +272,10 @@
       {
         "action": "added",
         "timestamp": 1737568701
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -280,6 +304,10 @@
       {
         "action": "added",
         "timestamp": 1759311633
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -388,6 +416,10 @@
       {
         "action": "added",
         "timestamp": 1735915734
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -432,6 +464,10 @@
       {
         "action": "added",
         "timestamp": 1735552834
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -488,6 +524,10 @@
       {
         "action": "added",
         "timestamp": 1742312040
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -560,6 +600,10 @@
       {
         "action": "added",
         "timestamp": 1761911979
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -873,6 +917,10 @@
       {
         "action": "added",
         "timestamp": 1758125567
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -929,6 +977,10 @@
       {
         "action": "added",
         "timestamp": 1727711731
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -953,6 +1005,10 @@
       {
         "action": "added",
         "timestamp": 1759312015
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -1201,6 +1257,10 @@
       {
         "action": "added",
         "timestamp": 1762624371
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -1298,6 +1358,10 @@
       {
         "action": "added",
         "timestamp": 1762611127
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -1447,6 +1511,10 @@
       {
         "action": "added",
         "timestamp": 1757062478
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -1535,6 +1603,10 @@
       {
         "action": "added",
         "timestamp": 1724673384
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -1563,6 +1635,10 @@
       {
         "action": "added",
         "timestamp": 1760555740
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -1648,6 +1724,10 @@
       {
         "action": "added",
         "timestamp": 1738683644
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -1660,6 +1740,10 @@
       {
         "action": "added",
         "timestamp": 1738683644
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -1700,6 +1784,10 @@
       {
         "action": "added",
         "timestamp": 1736348517
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -1712,6 +1800,10 @@
       {
         "action": "added",
         "timestamp": 1738072868
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -1796,6 +1888,10 @@
       {
         "action": "added",
         "timestamp": 1741272183
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -1944,6 +2040,10 @@
       {
         "action": "added",
         "timestamp": 1718041891
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -2072,6 +2172,10 @@
       {
         "action": "added",
         "timestamp": 1759311936
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -2140,6 +2244,10 @@
       {
         "action": "added",
         "timestamp": 1758100850
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -2152,6 +2260,10 @@
       {
         "action": "added",
         "timestamp": 1758195539
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -2314,6 +2426,10 @@
       {
         "action": "added",
         "timestamp": 1762616749
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -2439,6 +2555,10 @@
       {
         "action": "added",
         "timestamp": 1718268841
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -2483,6 +2603,10 @@
       {
         "action": "added",
         "timestamp": 1757948504
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -2735,6 +2859,10 @@
       {
         "action": "added",
         "timestamp": 1738661763
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -2863,6 +2991,10 @@
       {
         "action": "added",
         "timestamp": 1753097465
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -2947,6 +3079,10 @@
       {
         "action": "added",
         "timestamp": 1742374295
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -2959,6 +3095,10 @@
       {
         "action": "added",
         "timestamp": 1757509552
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -2971,6 +3111,10 @@
       {
         "action": "added",
         "timestamp": 1742374295
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -2983,6 +3127,10 @@
       {
         "action": "added",
         "timestamp": 1757583546
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -3007,6 +3155,10 @@
       {
         "action": "added",
         "timestamp": 1741251789
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -3127,6 +3279,10 @@
       {
         "action": "added",
         "timestamp": 1742370799
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -3211,6 +3367,10 @@
       {
         "action": "added",
         "timestamp": 1744187642
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -3291,6 +3451,10 @@
       {
         "action": "added",
         "timestamp": 1747121370
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -3351,6 +3515,10 @@
       {
         "action": "added",
         "timestamp": 1754484079
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -3407,6 +3575,10 @@
       {
         "action": "added",
         "timestamp": 1748677234
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -3567,6 +3739,10 @@
       {
         "action": "added",
         "timestamp": 1748858260
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -3579,6 +3755,10 @@
       {
         "action": "added",
         "timestamp": 1748858260
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -3615,6 +3795,10 @@
       {
         "action": "added",
         "timestamp": 1748425128
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -3659,6 +3843,10 @@
       {
         "action": "added",
         "timestamp": 1757062535
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -3687,6 +3875,10 @@
       {
         "action": "added",
         "timestamp": 1748553109
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -3819,6 +4011,10 @@
       {
         "action": "added",
         "timestamp": 1750157487
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -3875,6 +4071,10 @@
       {
         "action": "added",
         "timestamp": 1750851563
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -3899,6 +4099,10 @@
       {
         "action": "added",
         "timestamp": 1751220000
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -3923,6 +4127,10 @@
       {
         "action": "added",
         "timestamp": 1751220000
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -4079,6 +4287,10 @@
       {
         "action": "added",
         "timestamp": 1751350044
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -4091,6 +4303,10 @@
       {
         "action": "added",
         "timestamp": 1760728465
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -4195,6 +4411,10 @@
       {
         "action": "added",
         "timestamp": 1751518105
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -4292,6 +4512,10 @@
       {
         "action": "added",
         "timestamp": 1758724137
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   },
@@ -4412,6 +4636,10 @@
       {
         "action": "added",
         "timestamp": 1759997565
+      },
+      {
+        "action": "removed",
+        "timestamp": 1775743909
       }
     ]
   }


### PR DESCRIPTION
Remove 57 V1 vaults from Morpho frontend listing
Reason: under 100k TVL