### PR TITLE
add ci validation for blacklist json datasets

### DIFF
--- a/test/json/validation/markets-blacklist.test.ts
+++ b/test/json/validation/markets-blacklist.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "@jest/globals";
+import { loadJsonFile, VALID_CHAIN_IDS } from "../../utils/jsonValidators";
+
+interface MarketBlacklistEntry {
+  id: string;
+  chainId: number;
+  countryCodes: string[];
+}
+
+const MARKET_ID_HEX = /^0x[a-fA-F0-9]{64}$/;
+
+/** ISO 3166-1 alpha-2 or "*" for all regions (see README markets blacklist). */
+function isValidCountryCode(code: string): boolean {
+  if (code === "*") return true;
+  return /^[A-Z]{2}$/.test(code);
+}
+
+describe("markets-blacklist.json validation", () => {
+  const entries = loadJsonFile("markets-blacklist.json") as MarketBlacklistEntry[];
+
+  test("file is a non-empty array", () => {
+    expect(Array.isArray(entries)).toBe(true);
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  test("each entry has id, chainId, and countryCodes with correct types", () => {
+    const errors: string[] = [];
+    entries.forEach((row, index) => {
+      if (typeof row.id !== "string" || !row.id) {
+        errors.push(`index ${index}: id must be a non-empty string`);
+      }
+      if (typeof row.chainId !== "number" || !Number.isInteger(row.chainId)) {
+        errors.push(`index ${index}: chainId must be an integer`);
+      }
+      if (!Array.isArray(row.countryCodes) || row.countryCodes.length === 0) {
+        errors.push(`index ${index}: countryCodes must be a non-empty array`);
+      }
+    });
+    if (errors.length) throw new Error(errors.join("\n"));
+  });
+
+  test("each market id is a 32-byte hex string", () => {
+    const errors: string[] = [];
+    entries.forEach((row, index) => {
+      if (!MARKET_ID_HEX.test(row.id)) {
+        errors.push(
+          `index ${index}: invalid market id (expected 0x + 64 hex chars): ${row.id}`
+        );
+      }
+    });
+    if (errors.length) throw new Error(errors.join("\n"));
+  });
+
+  test("chain IDs are supported", () => {
+    const allowed = new Set<number>(VALID_CHAIN_IDS);
+    const errors: string[] = [];
+    entries.forEach((row, index) => {
+      if (!allowed.has(row.chainId)) {
+        errors.push(`index ${index}: unsupported chainId ${row.chainId}`);
+      }
+    });
+    if (errors.length) throw new Error(errors.join("\n"));
+  });
+
+  test("country codes are ISO 3166-1 alpha-2 or *", () => {
+    const errors: string[] = [];
+    entries.forEach((row, index) => {
+      row.countryCodes.forEach((code, cIdx) => {
+        if (typeof code !== "string" || !isValidCountryCode(code)) {
+          errors.push(
+            `index ${index}, countryCodes[${cIdx}]: invalid code "${code}" (use two uppercase letters or *)`
+          );
+        }
+      });
+    });
+    if (errors.length) throw new Error(errors.join("\n"));
+  });
+
+  test("no duplicate id + chainId pairs", () => {
+    const seen = new Map<string, number>();
+    const dupes: string[] = [];
+    entries.forEach((row, index) => {
+      const key = `${row.chainId}:${row.id.toLowerCase()}`;
+      const first = seen.get(key);
+      if (first !== undefined) {
+        dupes.push(`duplicate id ${row.id} on chain ${row.chainId} (indices ${first} and ${index})`);
+      } else {
+        seen.set(key, index);
+      }
+    });
+    expect(dupes).toEqual([]);
+  });
+});

--- a/test/json/validation/merkl-campaigns-blacklist.test.ts
+++ b/test/json/validation/merkl-campaigns-blacklist.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "@jest/globals";
+import { loadJsonFile } from "../../utils/jsonValidators";
+
+interface MerklCampaignEntry {
+  campaignId: string;
+}
+
+describe("merkl-campaigns-blacklist.json validation", () => {
+  const entries = loadJsonFile("merkl-campaigns-blacklist.json") as MerklCampaignEntry[];
+
+  test("file is a non-empty array", () => {
+    expect(Array.isArray(entries)).toBe(true);
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  test("each entry has a non-empty numeric campaignId string", () => {
+    const errors: string[] = [];
+    const idPattern = /^\d+$/;
+    entries.forEach((row, index) => {
+      if (typeof row.campaignId !== "string" || !row.campaignId) {
+        errors.push(`index ${index}: campaignId must be a non-empty string`);
+      } else if (!idPattern.test(row.campaignId)) {
+        errors.push(`index ${index}: campaignId must contain only digits: ${row.campaignId}`);
+      }
+    });
+    if (errors.length) throw new Error(errors.join("\n"));
+  });
+
+  test("no duplicate campaignId", () => {
+    const seen = new Map<string, number>();
+    const dupes: string[] = [];
+    entries.forEach((row, index) => {
+      const first = seen.get(row.campaignId);
+      if (first !== undefined) {
+        dupes.push(`duplicate campaignId ${row.campaignId} at indices ${first} and ${index}`);
+      } else {
+        seen.set(row.campaignId, index);
+      }
+    });
+    expect(dupes).toEqual([]);
+  });
+});

--- a/test/json/validation/merkl-single-token-blacklist.test.ts
+++ b/test/json/validation/merkl-single-token-blacklist.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "@jest/globals";
+import { loadJsonFile, VALID_CHAIN_IDS } from "../../utils/jsonValidators";
+
+interface MerklSingleTokenEntry {
+  market: string;
+  chainId: number;
+}
+
+const MARKET_ID_HEX = /^0x[a-fA-F0-9]{64}$/;
+
+describe("merkl-single-token-blacklist.json validation", () => {
+  const entries = loadJsonFile("merkl-single-token-blacklist.json") as MerklSingleTokenEntry[];
+
+  test("file is a non-empty array", () => {
+    expect(Array.isArray(entries)).toBe(true);
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  test("each entry has market id and chainId with correct types", () => {
+    const errors: string[] = [];
+    entries.forEach((row, index) => {
+      if (typeof row.market !== "string" || !row.market) {
+        errors.push(`index ${index}: market must be a non-empty string`);
+      }
+      if (typeof row.chainId !== "number" || !Number.isInteger(row.chainId)) {
+        errors.push(`index ${index}: chainId must be an integer`);
+      }
+    });
+    if (errors.length) throw new Error(errors.join("\n"));
+  });
+
+  test("each market id is a 32-byte hex string", () => {
+    const errors: string[] = [];
+    entries.forEach((row, index) => {
+      if (!MARKET_ID_HEX.test(row.market)) {
+        errors.push(
+          `index ${index}: invalid market id (expected 0x + 64 hex chars): ${row.market}`
+        );
+      }
+    });
+    if (errors.length) throw new Error(errors.join("\n"));
+  });
+
+  test("chain IDs are supported", () => {
+    const allowed = new Set<number>(VALID_CHAIN_IDS);
+    const errors: string[] = [];
+    entries.forEach((row, index) => {
+      if (!allowed.has(row.chainId)) {
+        errors.push(`index ${index}: unsupported chainId ${row.chainId}`);
+      }
+    });
+    if (errors.length) throw new Error(errors.join("\n"));
+  });
+
+  test("no duplicate market + chainId pairs", () => {
+    const seen = new Map<string, number>();
+    const dupes: string[] = [];
+    entries.forEach((row, index) => {
+      const key = `${row.chainId}:${row.market.toLowerCase()}`;
+      const first = seen.get(key);
+      if (first !== undefined) {
+        dupes.push(
+          `duplicate market on chain ${row.chainId} (indices ${first} and ${index})`
+        );
+      } else {
+        seen.set(key, index);
+      }
+    });
+    expect(dupes).toEqual([]);
+  });
+});

--- a/test/json/validation/token-pricing-blacklist.test.ts
+++ b/test/json/validation/token-pricing-blacklist.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "@jest/globals";
+import { getAddress } from "viem";
+import { loadJsonFile, VALID_CHAIN_IDS } from "../../utils/jsonValidators";
+
+interface TokenPricingBlacklistEntry {
+  address: string;
+  chainId: number;
+}
+
+describe("token-pricing-blacklist.json validation", () => {
+  const entries = loadJsonFile("token-pricing-blacklist.json") as TokenPricingBlacklistEntry[];
+
+  test("file is an array", () => {
+    expect(Array.isArray(entries)).toBe(true);
+  });
+
+  test("each entry has checksummed address and integer chainId", () => {
+    const errors: string[] = [];
+    entries.forEach((row, index) => {
+      if (typeof row.address !== "string" || !row.address) {
+        errors.push(`index ${index}: address must be a non-empty string`);
+        return;
+      }
+      try {
+        const checksummed = getAddress(row.address);
+        if (row.address !== checksummed) {
+          errors.push(
+            `index ${index}: address must be checksummed (expected ${checksummed}, got ${row.address})`
+          );
+        }
+      } catch {
+        errors.push(`index ${index}: invalid address ${row.address}`);
+      }
+      if (typeof row.chainId !== "number" || !Number.isInteger(row.chainId)) {
+        errors.push(`index ${index}: chainId must be an integer`);
+      }
+    });
+    if (errors.length) throw new Error(errors.join("\n"));
+  });
+
+  test("chain IDs are supported", () => {
+    const allowed = new Set<number>(VALID_CHAIN_IDS);
+    const errors: string[] = [];
+    entries.forEach((row, index) => {
+      if (!allowed.has(row.chainId)) {
+        errors.push(`index ${index}: unsupported chainId ${row.chainId}`);
+      }
+    });
+    if (errors.length) throw new Error(errors.join("\n"));
+  });
+
+  test("no duplicate address + chainId pairs", () => {
+    const seen = new Map<string, number>();
+    const dupes: string[] = [];
+    entries.forEach((row, index) => {
+      const key = `${row.chainId}:${row.address.toLowerCase()}`;
+      const first = seen.get(key);
+      if (first !== undefined) {
+        dupes.push(
+          `duplicate ${row.address} on chain ${row.chainId} (indices ${first} and ${index})`
+        );
+      } else {
+        seen.set(key, index);
+      }
+    });
+    expect(dupes).toEqual([]);
+  });
+});


### PR DESCRIPTION
## what this does

The test suite already validates most JSON under `data/`, but four files that ship with the API had **no automated checks** in CI:

- `markets-blacklist.json` (geo / compliance rules for markets)
- `token-pricing-blacklist.json`
- `merkl-campaigns-blacklist.json`
- `merkl-single-token-blacklist.json`

That meant bad edits (wrong market id shape, duplicate rows, bad chain ids, non-checksummed token addresses, etc.) could merge without the suite failing.

This PR adds Jest validation for those files: schema-ish checks, chain id allowlist alignment with `VALID_CHAIN_IDS`, duplicate detection, and hex/id formats consistent with the rest of the repo.

## summary

made by mooncitydev

