### PR TITLE
feat(curator): add vPay

### DIFF
--- a/data/curators-listing.json
+++ b/data/curators-listing.json
@@ -956,5 +956,20 @@
       "twitter": "https://x.com/unifiedlabs_",
       "forum": "https://forum.morpho.org/c/vaults/unified-labs/61"
     }
+  },
+  {
+    "image": "https://cdn.morpho.org/v2/assets/images/vpay.png",
+    "name": "vPay",
+    "verified": true,
+    "addresses": {
+      "8453": [
+        "0xC9a9431dBC926f60EA8D96D0498EfBD887DfE4b1"
+      ]
+    },
+    "id": "vpay",
+    "socials": {
+      "url": "https://app.vpay.fund",
+      "twitter": "https://x.com/vPay_Global"
+    }
   }
 ]


### PR DESCRIPTION
Adds vPay as a verified curator. Live vault on Base proving on-chain role: `0x8c36241D7FB6551af40E7f78Fee88aD0e89Dfb52`.

Logo source: https://app.vpay.fund/icons/vpay-v-logo.webp